### PR TITLE
Basic FirstPersonView Implemented, strafe controls (prototype)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ src/Headers/version.h
 .vs/
 /.vscode
 /.idea
+*.aps
 
 # macOS metadata
 .DS_Store

--- a/src/3D/Camera.c
+++ b/src/3D/Camera.c
@@ -47,6 +47,7 @@ Boolean				gDrawLensFlare = true, gFreezeCameraFromXZ = false, gFreezeCameraFrom
 Boolean				gForceCameraAlignment = false;
 
 float				gCameraUserRotY = 0;
+float				mouseDistY;
 float				gPlayerToCameraAngle = 0.0f;
 static float		gCameraLookAtAccel,gCameraFromAccelY,gCameraFromAccel;
 float		gCameraDistFromMe, gCameraHeightFactor,gCameraLookAtYOff;
@@ -260,8 +261,8 @@ ObjNode	*playerObj = gPlayerInfo.objNode;
 	{
 		float	dx,dz,x,z,r;
 
-		// r = playerObj->Rot.y + PI + PI/9; // Use player Rot y directly 
-		r = playerObj->Rot.y;
+		r = playerObj->Rot.y + PI + PI/9; // Use player Rot y directly 
+		// r = playerObj->Rot.y;
 
 		dx = sin(r) * 1800.0f;
 		dz = cos(r) * 1800.0f;
@@ -289,6 +290,7 @@ static void ResetCameraSettings(void)
 	gForceCameraAlignment = false;
 
 	gCameraUserRotY = 0;
+	mouseDistY = 0;
 
 	gCameraFromAccel 	= 4.5;
 	gCameraFromAccelY	= 1.5;
@@ -370,13 +372,28 @@ int			firstPersonHeight = 100;
 			/**********************/
 
 
-	to.x = sin(playerObj->Rot.y + PI);
-	to.y = playerObj->Coord.y + firstPersonHeight;
-	to.z = cos(playerObj->Rot.y + PI);
+	mouseDistY += gCameraControlDelta.y;
 
-	to.x += playerObj->Coord.x;
-	to.z += playerObj->Coord.z;
+	float limit = 3.2;
+	
+	// Lock the view to upper max and lower max
+	if (mouseDistY > limit)
+		mouseDistY = limit;
+	if (mouseDistY < -limit)
+		mouseDistY = -limit;
 
+	// Mouse Y axis slows down at the top and bottom limits, à la SDL3D???
+	
+	// Basic FPS view, locked to robot facing-forward view:
+	to.y = playerObj->Coord.y + firstPersonHeight - mouseDistY;
+	to.x = sin(playerObj->Rot.y + PI) + playerObj->Coord.x;
+	to.z = cos(playerObj->Rot.y + PI) + playerObj->Coord.z;
+
+
+	// Test logging of mouseDistY breakpoint
+	if ((int)fps % 60) {
+		//mouseDistY = mouseDistY;
+	}
 
 
 
@@ -414,7 +431,7 @@ int			firstPersonHeight = 100;
 				/**********************/
 				/* UPDATE CAMERA INFO */
 				/**********************/
-
+	/*
 	if (gGamePrefs.snappyCameraControl
 		&& gCameraControlDelta.x != 0
 		&& !gAutoRotateCamera)
@@ -427,14 +444,14 @@ int			firstPersonHeight = 100;
 		OGLMatrix4x4_SetRotateAboutPoint(&m, &to, 0, r, 0);
 		OGLPoint3D_Transform(&from, &m, &from);
 	}
+	*/
 
-
-	if (gAutoRotateCamera && gFreezeCameraFromXZ)				// special auto-rot for frozen xz condition
-	{
-		OGLMatrix4x4	m;
-		OGLMatrix4x4_SetRotateAboutPoint(&m, &to, 0, fps * gAutoRotateCameraSpeed, 0);
-		OGLPoint3D_Transform(&from, &m, &from);
-	}
+	//if (gAutoRotateCamera && gFreezeCameraFromXZ)				// special auto-rot for frozen xz condition
+	//{
+	//	OGLMatrix4x4	m;
+	//	OGLMatrix4x4_SetRotateAboutPoint(&m, &to, 0, fps * gAutoRotateCameraSpeed, 0);
+	//	OGLPoint3D_Transform(&from, &m, &from);
+	//}
 
 
 	OGL_UpdateCameraFromTo(gGameViewInfoPtr,&from,&to);

--- a/src/3D/Camera.c
+++ b/src/3D/Camera.c
@@ -290,11 +290,14 @@ static void ResetCameraSettings(void)
 	gCameraFromAccelY	= 1.5;
 
 
-
+	// Disable this camera modification for first person
+	/*
 	if (gLevelNum == LEVEL_NUM_BLOBBOSS)			// keep camera high on blob boss level
 		gMinHeightOffGround = 400;
 	else
 		gMinHeightOffGround = 60;
+
+	*/
 
 			/* SPECIAL SETTINGS FOR SAUCER LEVEL */
 
@@ -375,6 +378,12 @@ float			oldCamX,oldCamZ,oldCamY,oldPointOfInterestX,oldPointOfInterestZ,oldPoint
 		/******************************************/
 		/* SEE IF THE USER WILL WANT SOME CONTROL */
 		/******************************************/
+	
+	// Forcing this always on is like always holding tab
+	// Might be required to always have camera behind player for first person view
+	// Testing in progress:
+	gForceCameraAlignment = true; // (forced always on to test)
+
 	if (gAutoRotateCamera)
 	{
 		gCameraUserRotY += fps * gAutoRotateCameraSpeed;
@@ -475,7 +484,7 @@ float			oldCamX,oldCamZ,oldCamY,oldPointOfInterestX,oldPointOfInterestZ,oldPoint
 		if ((gTimeSinceLastThrust > .5f) || gForceCameraAlignment || (gGamePrefs.playerRelControls)) 	// dont auto-align if player is being moved & we are not forcing it
 		{
 			float	r;
-			const float	ratio = .5;
+			const float	ratio = 5.5; // originally 0.5, increased to reduce acceleration
 			OGLVector2D	behind;
 
 					/* CALC PLAYER BEHIND VECTOR */

--- a/src/3D/Camera.c
+++ b/src/3D/Camera.c
@@ -47,7 +47,7 @@ Boolean				gDrawLensFlare = true, gFreezeCameraFromXZ = false, gFreezeCameraFrom
 Boolean				gForceCameraAlignment = false;
 
 float				gCameraUserRotY = 0;
-float				mouseDistY;
+float				mouseCameraAngleY;
 float				gPlayerToCameraAngle = 0.0f;
 static float		gCameraLookAtAccel,gCameraFromAccelY,gCameraFromAccel;
 float		gCameraDistFromMe, gCameraHeightFactor,gCameraLookAtYOff;
@@ -290,7 +290,7 @@ static void ResetCameraSettings(void)
 	gForceCameraAlignment = false;
 
 	gCameraUserRotY = 0;
-	mouseDistY = 0;
+	mouseCameraAngleY = 0;
 
 	gCameraFromAccel 	= 4.5;
 	gCameraFromAccelY	= 1.5;
@@ -372,27 +372,28 @@ int			firstPersonHeight = 100;
 			/**********************/
 
 
-	mouseDistY += gCameraControlDelta.y;
+	mouseCameraAngleY += gCameraControlDelta.y; // Add mouse distance travelled (vertical only) to Y dist
 
-	float limit = 3.2;
-	
 	// Lock the view to upper max and lower max
-	if (mouseDistY > limit)
-		mouseDistY = limit;
-	if (mouseDistY < -limit)
-		mouseDistY = -limit;
+	// PI/2 -> Would be directly straight up, and glitches lighting
+	// Stay at slightly less than PI to prevent issues
+	float limit = PI / 2.1;
+	if (mouseCameraAngleY > limit)
+		mouseCameraAngleY = limit;
+	if (mouseCameraAngleY < -limit)
+		mouseCameraAngleY = -limit;
 
 	// Mouse Y axis slows down at the top and bottom limits, à la SDL3D???
 	
 	// Basic FPS view, locked to robot facing-forward view:
-	to.y = playerObj->Coord.y + firstPersonHeight - mouseDistY;
-	to.x = sin(playerObj->Rot.y + PI) + playerObj->Coord.x;
-	to.z = cos(playerObj->Rot.y + PI) + playerObj->Coord.z;
+	to.y = playerObj->Coord.y + firstPersonHeight - sin(mouseCameraAngleY);
+	to.x = cos(mouseCameraAngleY) * sin(playerObj->Rot.y + PI) + playerObj->Coord.x;
+	to.z = cos(mouseCameraAngleY) * cos(playerObj->Rot.y + PI) + playerObj->Coord.z;
 
 
-	// Test logging of mouseDistY breakpoint
-	if ((int)fps % 60) {
-		//mouseDistY = mouseDistY;
+	// Test logging of mouseCameraAngleY breakpoint
+	if ((int)fps % 144) {
+		//mouseCameraAngleY = mouseCameraAngleY;
 	}
 
 

--- a/src/3D/Camera.c
+++ b/src/3D/Camera.c
@@ -370,9 +370,13 @@ int			firstPersonHeight = 100;
 			/**********************/
 			/* CALC LOOK AT POINT */
 			/**********************/
+	
+	
+	float verticalSens = 0.5f; // Reduce vertical axis camera speed
 
-
+	gCameraControlDelta.y *= verticalSens;
 	mouseCameraAngleY += gCameraControlDelta.y; // Add mouse distance travelled (vertical only) to Y dist
+	
 
 	// Lock the view to upper max and lower max
 	// PI/2 -> Would be directly straight up, and glitches lighting

--- a/src/3D/Camera.c
+++ b/src/3D/Camera.c
@@ -329,6 +329,7 @@ float		fps = gFramesPerSecondFrac;
 ObjNode		*playerObj = gPlayerInfo.objNode;
 SkeletonObjDataType	*skeleton;
 float			oldCamX,oldCamZ,oldCamY,oldPointOfInterestX,oldPointOfInterestZ,oldPointOfInterestY;
+int			firstPersonHeight = 100;
 
 	if (!playerObj)
 		return;
@@ -370,7 +371,7 @@ float			oldCamX,oldCamZ,oldCamY,oldPointOfInterestX,oldPointOfInterestZ,oldPoint
 
 
 	to.x = sin(playerObj->Rot.y + PI);
-	to.y = playerObj->Coord.y + 50;
+	to.y = playerObj->Coord.y + firstPersonHeight;
 	to.z = cos(playerObj->Rot.y + PI);
 
 	to.x += playerObj->Coord.x;
@@ -390,7 +391,7 @@ float			oldCamX,oldCamZ,oldCamY,oldPointOfInterestX,oldPointOfInterestZ,oldPoint
 	}
 	else
 	{
-		from.x = playerObj->Coord.x;
+		from.x = playerObj->Coord.x; // ( + a few hundred if needed to see body for testing )
 		from.z = playerObj->Coord.z;	
 	}
 
@@ -406,7 +407,7 @@ float			oldCamX,oldCamZ,oldCamY,oldPointOfInterestX,oldPointOfInterestZ,oldPoint
 	}
 	else
 	{
-		from.y = playerObj->Coord.y + 50;
+		from.y = playerObj->Coord.y + firstPersonHeight;
 	}
 
 

--- a/src/Headers/player.h
+++ b/src/Headers/player.h
@@ -190,7 +190,9 @@ typedef struct
 			/* CONTROL INFO */
 			
 	float				analogControlX,analogControlZ;
-	
+	// Needs to be separate from analogControlX so mouse & strafe can be independant:
+	float				strafeControlX; 
+
 	float				autoAimTimer;					// set when want player to auto-turn to aim at something
 	float				autoAimTargetX;
 	float				autoAimTargetZ;

--- a/src/Player/Player.c
+++ b/src/Player/Player.c
@@ -550,8 +550,9 @@ ObjNode	*door, *rocket;
 	gAutoRotateCameraSpeed 	= -.06f;
 	gPlayerHasLanded 		= false;
 
-	gFreezeCameraFromY 		= true;
-	gFreezeCameraFromXZ		= true;
+	// Set both of these to false for VR, to allow camera in player head during rocket scene:
+	gFreezeCameraFromY 		= false;
+	gFreezeCameraFromXZ		= false;
 
 				/*************/
 				/* MAKE SHIP */

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -90,11 +90,11 @@ static void VerifyTargetPickup(void);
 
 #define DEBUG_PLAYER_VAPOR		0
 #if DEBUG_PLAYER_VAPOR
-#define PLAYER_VAPOR_THRESHOLD	10.0f
-#define PLAYER_VAPOR_ALPHA		1.0f
+	#define PLAYER_VAPOR_THRESHOLD	10.0f
+	#define PLAYER_VAPOR_ALPHA		1.0f
 #else
-#define	PLAYER_VAPOR_THRESHOLD	700.0f
-#define PLAYER_VAPOR_ALPHA		0.2f
+	#define	PLAYER_VAPOR_THRESHOLD	700.0f
+	#define PLAYER_VAPOR_ALPHA		0.2f
 #endif
 
 #define	JUMP_DELTA					1800.0f
@@ -137,8 +137,8 @@ u_short			gPlayerTileAttribs;
 
 OGLVector3D		gPreCollisionDelta;
 
-ObjNode *gTargetPickup = nil;
-ObjNode *gCannon = nil;
+ObjNode 		*gTargetPickup = nil;
+ObjNode			*gCannon = nil;
 
 float			gPlayerBottomOff = 0;
 
@@ -173,43 +173,43 @@ float	gCurrentMaxSpeed = PLAYER_NORMAL_MAX_SPEED;
 
 void InitPlayer_Robot(OGLPoint3D *where, float rotY)
 {
-	ObjNode *newObj;
-	float	y;
-	int		i;
+ObjNode	*newObj;
+float	y;
+int		i;
 
-	/* FIND THE Y COORD TO START */
+		/* FIND THE Y COORD TO START */
 
-	y = FindHighestCollisionAtXZ(where->x, where->z, CTYPE_MISC | CTYPE_TERRAIN);
+	y = FindHighestCollisionAtXZ(where->x,where->z, CTYPE_MISC|CTYPE_TERRAIN);
 
-	if(gLevelNum == LEVEL_NUM_BLOBBOSS)
+	if (gLevelNum == LEVEL_NUM_BLOBBOSS)
 		y += 5000.0f;				// blob boss, player falls from above
 	else
-		y += -gObjectGroupBBoxList[MODEL_GROUP_SKELETONBASE + SKELETON_TYPE_OTTO][0].min.y * PLAYER_DEFAULT_SCALE + 5.0f;	// offset y so foot is on ground
+		y += -gObjectGroupBBoxList[MODEL_GROUP_SKELETONBASE+SKELETON_TYPE_OTTO][0].min.y * PLAYER_DEFAULT_SCALE + 5.0f;	// offset y so foot is on ground
 
 
 		/*****************************/
 		/* MAKE OTTO'S SKELETON BODY */
 		/*****************************/
 
-	gNewObjectDefinition.type = SKELETON_TYPE_OTTO;
-	gNewObjectDefinition.animNum = 0;
-	gNewObjectDefinition.coord.x = where->x;
-	gNewObjectDefinition.coord.z = where->z;
-	gNewObjectDefinition.coord.y = y;
-	gNewObjectDefinition.flags = STATUS_BIT_NOFOG | STATUS_BIT_DONTCULL;
-	gNewObjectDefinition.slot = PLAYER_SLOT;
-	gNewObjectDefinition.moveCall = MovePlayer_Robot;
-	gNewObjectDefinition.rot = 0;
-	gNewObjectDefinition.scale = PLAYER_DEFAULT_SCALE;
+	gNewObjectDefinition.type 		= SKELETON_TYPE_OTTO;
+	gNewObjectDefinition.animNum	= 0;
+	gNewObjectDefinition.coord.x 	= where->x;
+	gNewObjectDefinition.coord.z 	= where->z;
+	gNewObjectDefinition.coord.y 	= y;
+	gNewObjectDefinition.flags 		= STATUS_BIT_NOFOG|STATUS_BIT_DONTCULL;
+	gNewObjectDefinition.slot 		= PLAYER_SLOT;
+	gNewObjectDefinition.moveCall	= MovePlayer_Robot;
+	gNewObjectDefinition.rot 		= 0;
+	gNewObjectDefinition.scale 		= PLAYER_DEFAULT_SCALE;
 
 	newObj = MakeNewSkeletonObject(&gNewObjectDefinition);
 
-	gPlayerInfo.objNode = newObj;
+	gPlayerInfo.objNode 	= newObj;
 
 	newObj->Rot.y = rotY;
 
 
-	/* SET COLLISION INFO */
+				/* SET COLLISION INFO */
 
 	newObj->BoundingSphereRadius *= 2.0f;
 
@@ -219,46 +219,46 @@ void InitPlayer_Robot(OGLPoint3D *where, float rotY)
 	SetObjectCollisionBounds(newObj, newObj->BBox.max.y, gPlayerBottomOff = newObj->BBox.min.y, -40, 40, 40, -40);
 
 
-	/***********************/
-	/* CREATE HAND OBJECTS */
-	/***********************/
+		/***********************/
+		/* CREATE HAND OBJECTS */
+		/***********************/
 
-	for(i = 0; i < (GLOBAL_ObjType_FlameGunHand - GLOBAL_ObjType_OttoLeftHand + 1); i++)
+	for (i = 0; i < (GLOBAL_ObjType_FlameGunHand-GLOBAL_ObjType_OttoLeftHand+1); i++)
 	{
-		BG3D_SphereMapGeomteryMaterial(MODEL_GROUP_GLOBAL, GLOBAL_ObjType_OttoLeftHand + i, 0, MULTI_TEXTURE_COMBINE_ADD, SPHEREMAP_SObjType_DarkDusk);	// set this model to be sphere mapped
+		BG3D_SphereMapGeomteryMaterial(MODEL_GROUP_GLOBAL, GLOBAL_ObjType_OttoLeftHand+i, 0, MULTI_TEXTURE_COMBINE_ADD, SPHEREMAP_SObjType_DarkDusk);	// set this model to be sphere mapped
 	}
 
 
-	/* LEFT HAND */
+			/* LEFT HAND */
 
-	gNewObjectDefinition.group = MODEL_GROUP_GLOBAL;
-	gNewObjectDefinition.type = GLOBAL_ObjType_OttoLeftHand;
-	gNewObjectDefinition.slot = SLOT_OF_DUMB;
-	gNewObjectDefinition.moveCall = nil;
-	gPlayerInfo.leftHandObj = MakeNewDisplayGroupObject(&gNewObjectDefinition);
+	gNewObjectDefinition.group 		= MODEL_GROUP_GLOBAL;
+	gNewObjectDefinition.type 		= GLOBAL_ObjType_OttoLeftHand;
+	gNewObjectDefinition.slot		= SLOT_OF_DUMB;
+	gNewObjectDefinition.moveCall 	= nil;
+	gPlayerInfo.leftHandObj 		= MakeNewDisplayGroupObject(&gNewObjectDefinition);
 
 
 
-	/* RIGHT HAND */
+			/* RIGHT HAND */
 
-	gNewObjectDefinition.type = GLOBAL_ObjType_OttoRightHand;
-	gPlayerInfo.rightHandObj = MakeNewDisplayGroupObject(&gNewObjectDefinition);
+	gNewObjectDefinition.type 	= GLOBAL_ObjType_OttoRightHand;
+	gPlayerInfo.rightHandObj 	= MakeNewDisplayGroupObject(&gNewObjectDefinition);
 
 	gPlayerInfo.rightHandObj->Kind = WEAPON_TYPE_FIST;			// set weapon type since this gets passed to weapon handlers
 
 	gPlayerInfo.rightHandObj->Damage = PUNCH_DAMAGE;
 
 
-	/*******************/
-	/* SET OTHER STUFF */
-	/*******************/
+		/*******************/
+		/* SET OTHER STUFF */
+		/*******************/
 
 	gTargetMaxSpeed = PLAYER_NORMAL_MAX_SPEED;
 	gCurrentMaxSpeed = PLAYER_NORMAL_MAX_SPEED;
 
 
 
-	AttachShadowToObject(newObj, 0, DEFAULT_PLAYER_SHADOW_SCALE, DEFAULT_PLAYER_SHADOW_SCALE * .8f, true);
+	AttachShadowToObject(newObj, 0, DEFAULT_PLAYER_SHADOW_SCALE,DEFAULT_PLAYER_SHADOW_SCALE * .8f, true);
 
 	CreatePlayerSparkles(newObj);
 
@@ -318,23 +318,23 @@ void MovePlayer_Robot(ObjNode *theNode)
 
 	GetObjectInfo(theNode);
 
-	if(gPlayerHasLanded)								// inc thrust timer since assume no thrust this frame
+	if (gPlayerHasLanded)								// inc thrust timer since assume no thrust this frame
 	{
 		gTimeSinceLastThrust += gFramesPerSecondFrac;
 		gTimeSinceLastShoot += gFramesPerSecondFrac;
 	}
 
-	/* FIRST SEE IF NEED TO UPDATE GROWTH */
+			/* FIRST SEE IF NEED TO UPDATE GROWTH */
 
 	UpdatePlayerGrowth(theNode);
 
 
-	/* JUMP TO HANDLER */
+			/* JUMP TO HANDLER */
 
 	myMoveTable[theNode->Skeleton->AnimNum](theNode);
 
 
-	/* SEE IF SHOULD FREEZE CAMERA */
+		/* SEE IF SHOULD FREEZE CAMERA */
 
 	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMPJET)		// dont move camera from during jump-jet
 		gFreezeCameraFromXZ = false; // Do move it in VR
@@ -355,31 +355,31 @@ static void MovePlayerRobot_Stand(ObjNode *theNode)
 
 	UpdatePlayerAutoAim(theNode);
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NORMAL, false))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NORMAL, false))
 		goto update;
 
 
-	/* SEE IF SHOULD WALK */
+			/* SEE IF SHOULD WALK */
 
-	if(IsPlayerDoingStandAnim(theNode))
+	if (IsPlayerDoingStandAnim(theNode))
 	{
-		float	animSpeed = CalcWalkAnimSpeed(theNode);
+		float	animSpeed =  CalcWalkAnimSpeed(theNode);
 
-		if((animSpeed > WALK_STAND_THRESHOLD) && (gTimeSinceLastThrust < THRUST_TIMER))
+		if ((animSpeed > WALK_STAND_THRESHOLD) && (gTimeSinceLastThrust < THRUST_TIMER))
 			SetPlayerWalkAnim(theNode);
 	}
 
-	/* DO CONTROL */
-	//
-	// do this last since we want any jump command to work smoothly
-	//
+			/* DO CONTROL */
+			//
+			// do this last since we want any jump command to work smoothly
+			//
 
 	CheckPlayerActionControls(theNode);
 
 
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -398,12 +398,12 @@ static void MovePlayerRobot_Walk(ObjNode *theNode)
 	CheckPlayerActionControls(theNode);
 
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
 	UpdatePlayerAutoAim(theNode);
 
-	if((gPlayerInfo.analogControlX == 0.0f) &&			// if no user control, do heavy friction
-		(gPlayerInfo.analogControlZ == 0.0f))
+	if ((gPlayerInfo.analogControlX == 0.0f) &&			// if no user control, do heavy friction
+		 (gPlayerInfo.analogControlZ == 0.0f))
 	{
 		DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
 	}
@@ -412,17 +412,17 @@ static void MovePlayerRobot_Walk(ObjNode *theNode)
 		DoRobotFrictionAndGravity(theNode, PLAYER_DEFAULT_FRICTION);
 	}
 
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NORMAL, false))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NORMAL, false))
 		goto update;
 
 
-	/* SEE IF SHOULD STAND */
+			/* SEE IF SHOULD STAND */
 
-	if(IsPlayerDoingWalkAnim(theNode))
+	if (IsPlayerDoingWalkAnim(theNode))
 	{
-		float	animSpeed = CalcWalkAnimSpeed(theNode);
+		float	animSpeed =  CalcWalkAnimSpeed(theNode);
 
-		if((animSpeed < WALK_STAND_THRESHOLD) || (gTimeSinceLastThrust > THRUST_TIMER))
+		if ((animSpeed < WALK_STAND_THRESHOLD) || (gTimeSinceLastThrust > THRUST_TIMER))
 			SetPlayerStandAnim(theNode, 8);
 		else
 			theNode->Skeleton->AnimSpeed = animSpeed * .004f;
@@ -430,7 +430,7 @@ static void MovePlayerRobot_Walk(ObjNode *theNode)
 
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -440,7 +440,7 @@ update:
 
 static float CalcWalkAnimSpeed(ObjNode *theNode)
 {
-	float	animSpeed, accSpeed;
+float	animSpeed,accSpeed;
 
 	accSpeed = sqrt(theNode->AccelVector.x * theNode->AccelVector.x + theNode->AccelVector.y * theNode->AccelVector.y);		// calc dist of accel vector
 	accSpeed *= 1000.0f;
@@ -449,7 +449,7 @@ static float CalcWalkAnimSpeed(ObjNode *theNode)
 
 				/* NOW ACCOUNT FOR GIANT SCALE */
 
-	if(theNode->Scale.x != PLAYER_DEFAULT_SCALE)
+	if (theNode->Scale.x != PLAYER_DEFAULT_SCALE)
 	{
 		float	f;
 
@@ -465,47 +465,47 @@ static float CalcWalkAnimSpeed(ObjNode *theNode)
 
 static void MovePlayerRobot_Jump(ObjNode *theNode)
 {
-	Byte	aimMode;
+Byte	aimMode;
 
-	/* DO CONTROL */
+			/* DO CONTROL */
 
 	CheckPlayerActionControls(theNode);
 
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
-	if(gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
+	if (gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
 		aimMode = AIM_MODE_NONE;
 	else
 		aimMode = AIM_MODE_NORMAL;
 
 	DoRobotFrictionAndGravity(theNode, PLAYER_AIR_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, aimMode, false))
+	if (DoPlayerMovementAndCollision(theNode, aimMode, false))
 		goto update;
 
 
-	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)		// only bother if still in Fall anim
+	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)		// only bother if still in Fall anim
 	{
-		/* SEE IF LANDED */
+				/* SEE IF LANDED */
 
-		if(theNode->StatusBits & STATUS_BIT_ONGROUND)
+		if (theNode->StatusBits & STATUS_BIT_ONGROUND)
 		{
 			SetPlayerStandAnim(theNode, 8);
 		}
 
-		/* SEE IF FALLING */
+				/* SEE IF FALLING */
 		else
-			if(gDelta.y < 0.0f)
-			{
-				if(gDoJumpJetAtApex)							// see if we wanted to jet @ the apex
-					StartJumpJet(theNode);
-				else
-					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);
-			}
+		if (gDelta.y < 0.0f)
+		{
+			if (gDoJumpJetAtApex)							// see if we wanted to jet @ the apex
+				StartJumpJet(theNode);
+			else
+				MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);
+		}
 	}
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -515,53 +515,53 @@ update:
 
 static void MovePlayerRobot_PickupAndDeposit(ObjNode *theNode)
 {
-	OGLMatrix4x4	m, m2;
+OGLMatrix4x4	m,m2;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
 	VerifyTargetPickup();
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
-	/* KEEP AIMED AT TARGET */
+			/* KEEP AIMED AT TARGET */
 
-	if(gTargetPickup && (!theNode->IsHoldingPickup))
+	if (gTargetPickup && (!theNode->IsHoldingPickup))
 	{
 		TurnObjectTowardTarget(theNode, &gCoord, gTargetPickup->Coord.x,
-			gTargetPickup->Coord.z, 9.0, false);
+								gTargetPickup->Coord.z, 9.0, false);
 	}
 
-	/* SEE IF DONE */
+			/* SEE IF DONE */
 
-	if(theNode->Skeleton->AnimHasStopped)										// go to stand when done with anim
+	if (theNode->Skeleton->AnimHasStopped)										// go to stand when done with anim
 		SetPlayerStandAnim(theNode, 2);
 
-	if(theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPDEPOSIT)				// if anim has changed then finish things up with the pickup
+	if (theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPDEPOSIT)				// if anim has changed then finish things up with the pickup
 	{
-		if(theNode->IsHoldingPickup)											// if we had it then add it
+		if (theNode->IsHoldingPickup)											// if we had it then add it
 		{
 			theNode->IsHoldingPickup = false;
 
-			if(gTargetPickup != nil)											// verify that there's a target
+			if (gTargetPickup != nil)											// verify that there's a target
 			{
 				AddPowerupToInventory(gTargetPickup);
 				PlayEffect3D(EFFECT_WEAPONDEPOSIT, &gCoord);
 
 
-				if(gTargetPickup->CType & CTYPE_BLOBPOW) 				 			// special check for blobule powerups
+				if (gTargetPickup->CType & CTYPE_BLOBPOW) 				 			// special check for blobule powerups
 					DisableHelpType(HELP_MESSAGE_SLIMEBALLS);						// picked up a blob so dont need to help on this anymore
 
-				if(gTargetPickup->POWRegenerate)							// if regeneratable, then just hide until needed
+				if (gTargetPickup->POWRegenerate)							// if regeneratable, then just hide until needed
 				{
 					gTargetPickup->MoveCall = MovePowerup;					// restore the Move Call
 					gTargetPickup->StatusBits |= STATUS_BIT_HIDDEN;
-					if(gTargetPickup->ShadowNode)							// and hide shadow
+					if (gTargetPickup->ShadowNode)							// and hide shadow
 						gTargetPickup->ShadowNode->StatusBits |= STATUS_BIT_HIDDEN;
 
 					gTargetPickup->CType = 0;								// no collision when hidden
@@ -576,29 +576,29 @@ static void MovePlayerRobot_PickupAndDeposit(ObjNode *theNode)
 	}
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
 
 
 
-	/*********************/
-	/* UPDATE THE PICKUP */
-	/*********************/
+		/*********************/
+		/* UPDATE THE PICKUP */
+		/*********************/
 
-	if(gTargetPickup && theNode->IsHoldingPickup)
+	if (gTargetPickup && theNode->IsHoldingPickup)
 	{
 		gTargetPickup->MoveCall = nil;										// make sure the pickup no longer has control if itself
 
-		OGLMatrix4x4_SetTranslate(&m, 0, -20, 0);								// set offset to palm of hand
+		OGLMatrix4x4_SetTranslate(&m,0,-20,0);								// set offset to palm of hand
 		m.value[M00] = gTargetPickup->Scale.x;								// insert scale values
 		m.value[M11] = gTargetPickup->Scale.y;
 		m.value[M22] = gTargetPickup->Scale.z;
 
 		FindJointFullMatrix(theNode, PLAYER_JOINT_RIGHTHAND, &m2);
 		OGLMatrix4x4_Multiply(&m, &m2, &m2);
-		OGLMatrix4x4_SetScale(&m, 1.0f / theNode->Scale.x, 1.0f / theNode->Scale.x, 1.0f / theNode->Scale.x);	// cancel out the player's scale thats in that matrix
+		OGLMatrix4x4_SetScale(&m, 1.0f/theNode->Scale.x,1.0f/theNode->Scale.x,1.0f/theNode->Scale.x);	// cancel out the player's scale thats in that matrix
 		OGLMatrix4x4_Multiply(&m, &m2, &gTargetPickup->BaseTransformMatrix);
 
 		SetObjectTransformMatrix(gTargetPickup);
@@ -618,41 +618,41 @@ static void MovePlayerRobot_PickupAndHoldGun(ObjNode *theNode)
 
 	VerifyTargetPickup();
 
-	if(gTargetPickup)														// if not holding it yet, then keep aimed at it
+	if (gTargetPickup)														// if not holding it yet, then keep aimed at it
 	{
 		TurnObjectTowardTarget(theNode, &gCoord, gTargetPickup->Coord.x,
-			gTargetPickup->Coord.z, 9.0, false);
+								gTargetPickup->Coord.z, 9.0, false);
 	}
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
-	/* SEE IF DONE */
+			/* SEE IF DONE */
 
-	if(theNode->Skeleton->AnimHasStopped)
+	if (theNode->Skeleton->AnimHasStopped)
 		SetPlayerStandAnim(theNode, 4);
 
 
-	/* SEE IF GRAB IT NOW */
+			/* SEE IF GRAB IT NOW */
 
-	if(gTargetPickup)
+	if (gTargetPickup)
 	{
-		if((theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPANDHOLDGUN) || (theNode->IsHoldingPickup))
+		if ((theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPANDHOLDGUN) || (theNode->IsHoldingPickup))
 		{
 			PlayEffect3D(EFFECT_WEAPONCLICK, &gCoord);
 
 			AddPowerupToInventory(gTargetPickup);
 			theNode->IsHoldingPickup = false;
 
-			if(gTargetPickup->POWRegenerate)							// if regeneratable, then just hide until needed
+			if (gTargetPickup->POWRegenerate)							// if regeneratable, then just hide until needed
 			{
 				gTargetPickup->StatusBits |= STATUS_BIT_HIDDEN;
-				if(gTargetPickup->ShadowNode)							// and hide shadow
+				if (gTargetPickup->ShadowNode)							// and hide shadow
 					gTargetPickup->ShadowNode->StatusBits |= STATUS_BIT_HIDDEN;
 				gTargetPickup->CType = 0;
 			}
@@ -662,7 +662,7 @@ static void MovePlayerRobot_PickupAndHoldGun(ObjNode *theNode)
 		}
 	}
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -678,61 +678,61 @@ static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode *theNode)
 	VerifyTargetPickup();
 
 
-	/****************************/
-	/* MOVE DURING HOLDING PART */
-	/****************************/
+			/****************************/
+			/* MOVE DURING HOLDING PART */
+			/****************************/
 
-	if(theNode->IsHoldingPickup)
+	if (theNode->IsHoldingPickup)
 	{
 		DoPlayerMagnetSkiing(theNode);
 	}
 
-	/***************************/
-	/* MOVE DURING PICKUP PART */
-	/***************************/
+			/***************************/
+			/* MOVE DURING PICKUP PART */
+			/***************************/
 	else
 	{
 
-		/* MOVE PLAYER */
+				/* MOVE PLAYER */
 
 		gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 		DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-		if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+		if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 			goto update;
 
 
-		/* KEEP AIMED AT TARGET */
+				/* KEEP AIMED AT TARGET */
 
-		if(gTargetPickup && (!theNode->IsHoldingPickup))
+		if (gTargetPickup && (!theNode->IsHoldingPickup))
 		{
 			TurnObjectTowardTarget(theNode, &gCoord, gTargetPickup->Coord.x,
-				gTargetPickup->Coord.z, 9.0, false);
+									gTargetPickup->Coord.z, 9.0, false);
 		}
 	}
 
-	/* SEE IF DONE */
+			/* SEE IF DONE */
 
-	if(theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPANDHOLDMAGNET)			// if anim has changed then finish things up with the pickup
+	if (theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPANDHOLDMAGNET)			// if anim has changed then finish things up with the pickup
 	{
 		EndMagnetSkiing(theNode, false);
 	}
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
 
 
 
-	/*********************/
-	/* UPDATE THE MAGNET */
-	/*********************/
+		/*********************/
+		/* UPDATE THE MAGNET */
+		/*********************/
 
-	if(gTargetPickup && theNode->IsHoldingPickup)
+	if (gTargetPickup && theNode->IsHoldingPickup)
 	{
-		static const OGLPoint3D	off = { 0,0,10 };
-		OGLPoint3D	p1, p2;
+		static const OGLPoint3D	off = {0,0,10};
+		OGLPoint3D	p1,p2;
 
 		gTargetPickup->MoveCall = nil;										// make sure the pickup no longer has control if itself
 		gTargetPickup->CType = 0;											// no collision during this
@@ -746,14 +746,14 @@ update:
 		gTargetPickup->Coord.z = (p1.z + p2.z) * .5f;
 
 		gTargetPickup->Rot.y = theNode->Rot.y;								// match y rot to player
-		gTargetPickup->Rot.x = -PI / 2;										// flip to aim forward
+		gTargetPickup->Rot.x = -PI/2;										// flip to aim forward
 
 					/* UPDATE NODE */
 
 		UpdateObjectTransforms(gTargetPickup);
 		UpdateShadow(gTargetPickup);
 
-		DisplayHelpMessage(HELP_MESSAGE_LETGOMAGNET, 1.0, true);
+		DisplayHelpMessage(HELP_MESSAGE_LETGOMAGNET,1.0, true);
 	}
 }
 
@@ -762,9 +762,9 @@ update:
 
 static void VerifyTargetPickup(void)
 {
-	if(gTargetPickup)
+	if (gTargetPickup)
 	{
-		if(gTargetPickup->CType == INVALID_NODE_FLAG)
+		if (gTargetPickup->CType == INVALID_NODE_FLAG)
 		{
 			gTargetPickup = nil;
 		}
@@ -783,31 +783,31 @@ static void MovePlayerRobot_ChangeWeapon(ObjNode *theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
 
-	/* SEE IF DONE */
+			/* SEE IF DONE */
 
-	if(theNode->Skeleton->AnimHasStopped)
+	if (theNode->Skeleton->AnimHasStopped)
 	{
 		SetPlayerStandAnim(theNode, 3);
 	}
 
 
-	/* FAST WEAPON SWITCHING */
-	//
-	// Player can keep cycling weapons until Otto has started
-	// pulling out a new gun (ChangeWeapon anim flag)
-	//
+			/* FAST WEAPON SWITCHING */
+			//
+			// Player can keep cycling weapons until Otto has started
+			// pulling out a new gun (ChangeWeapon anim flag)
+			//
 
-	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON
+	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON
 		&& !theNode->ChangeWeapon)
 	{
 		CheckWeaponChangeControls(theNode);
 	}
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -843,33 +843,33 @@ static void MovePlayerRobot_SuckedIntoWell(ObjNode *theNode)
 static void MovePlayerRobot_Punch(ObjNode *theNode)
 {
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
 	TurnPlayerTowardPunchable(theNode);										// aim at punchable
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
-	/* SEE IF CHECK FOR PUNCH COLLISION */
+			/* SEE IF CHECK FOR PUNCH COLLISION */
 
-	if(theNode->PunchCanHurt)
+	if (theNode->PunchCanHurt)
 	{
 		CheckPunchCollision(theNode);
 
 	}
 
 
-	/* SEE IF SHOULD STAND */
+			/* SEE IF SHOULD STAND */
 
-	if(theNode->Skeleton->AnimHasStopped)
+	if (theNode->Skeleton->AnimHasStopped)
 	{
 		SetPlayerStandAnim(theNode, 8);
 	}
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -881,31 +881,31 @@ update:
 static void MovePlayerRobot_Throw(ObjNode *theNode)
 {
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
-	/* SEE IF CHECK FOR RELEASE DART */
+			/* SEE IF CHECK FOR RELEASE DART */
 
-	if(theNode->ThrowDartNow)
+	if (theNode->ThrowDartNow)
 	{
 		ThrowDart(theNode);
 		theNode->ThrowDartNow = false;
 	}
 
 
-	/* SEE IF SHOULD STAND */
+			/* SEE IF SHOULD STAND */
 
-	if(theNode->Skeleton->AnimHasStopped)
+	if (theNode->Skeleton->AnimHasStopped)
 	{
 		SetPlayerStandAnim(theNode, 4);
 	}
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -917,8 +917,8 @@ update:
 
 static void TurnPlayerTowardPunchable(ObjNode *player)
 {
-	ObjNode *thisNode, *nearest;
-	float	ex, ey, ez, dist, bestDist, maxDist;
+ObjNode *thisNode,*nearest;
+float	ex,ey,ez,dist,bestDist,maxDist;
 
 	bestDist = 10000000;
 	nearest = nil;
@@ -931,7 +931,7 @@ static void TurnPlayerTowardPunchable(ObjNode *player)
 
 	do
 	{
-		if(thisNode->HitByWeaponHandler[WEAPON_TYPE_FIST] == nil)					// only look for punchables
+		if (thisNode->HitByWeaponHandler[WEAPON_TYPE_FIST] == nil)					// only look for punchables
 			goto next;
 
 		ex = thisNode->Coord.x;									// get obj coords
@@ -939,23 +939,23 @@ static void TurnPlayerTowardPunchable(ObjNode *player)
 		ez = thisNode->Coord.z;
 
 		dist = CalcDistance(gCoord.x, gCoord.z, ex, ez);
-		if((dist < bestDist) && (dist < maxDist))				// see if best dist & close enough
+		if ((dist < bestDist) && (dist < maxDist))				// see if best dist & close enough
 		{
 			bestDist = dist;
 			nearest = thisNode;
 		}
 
-	next:
+next:
 		thisNode = thisNode->NextNode;							// next target node
-	} while(thisNode != nil);
+	}while(thisNode != nil);
 
 
-	/* THERE IS SOMETHING THERE */
+			/* THERE IS SOMETHING THERE */
 
-	if(nearest)
+	if (nearest)
 	{
 		TurnObjectTowardTarget(player, &gCoord, nearest->Coord.x,
-			nearest->Coord.z, 6.0, false);
+								nearest->Coord.z, 6.0, false);
 	}
 
 
@@ -968,32 +968,32 @@ static void MovePlayerRobot_JumpJet(ObjNode *theNode)
 {
 
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
-	if(DoPlayerMovementAndCollision_JumpJet(theNode))
+	if (DoPlayerMovementAndCollision_JumpJet(theNode))
 		goto update;
 
 
-	/* SEE IF LANDED */
+			/* SEE IF LANDED */
 
-	if(theNode->StatusBits & STATUS_BIT_ONGROUND)
+	if (theNode->StatusBits & STATUS_BIT_ONGROUND)
 	{
 		SetPlayerStandAnim(theNode, 7);
 	}
-	/* SEE IF DONE WITH JUMP-JET ANIM */
+			/* SEE IF DONE WITH JUMP-JET ANIM */
 	else
-		if(theNode->Skeleton->AnimHasStopped || GetNewNeedState(kNeed_Jump))
-		{
-			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);		// make fall anim
-		}
+	if (theNode->Skeleton->AnimHasStopped || GetNewNeedState(kNeed_Jump))
+	{
+		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);		// make fall anim
+	}
 
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 
-	if((theNode->Skeleton->AnimNum != PLAYER_ANIM_JUMPJET) &&
+	if ((theNode->Skeleton->AnimNum != PLAYER_ANIM_JUMPJET) &&
 		(theNode->Skeleton->AnimNum != PLAYER_ANIM_GIANTJUMPJET))		// if anything changed, then make sure to cleanup
 	{
 		EndJumpJet(theNode);
@@ -1010,8 +1010,8 @@ update:
 
 static void MovePlayerRobot_Fall(ObjNode *theNode)
 {
-	float	oldDY = gDelta.y;
-	Byte	aimMode;
+float	oldDY = gDelta.y;
+Byte	aimMode;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1019,73 +1019,73 @@ static void MovePlayerRobot_Fall(ObjNode *theNode)
 			/* SEE IF FALLING IN A BOTTOMLESS PIT DEATH */
 			/********************************************/
 
-	if(gPlayerFellIntoBottomlessPit)
+	if (gPlayerFellIntoBottomlessPit)
 	{
 		MovePlayerRobot_Fall_BottomlessPit(theNode);
 		return;
 	}
 
-	/* DO CONTROL */
+				/* DO CONTROL */
 
 	CheckPlayerActionControls(theNode);
 
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
-	if(gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
+	if (gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
 		aimMode = AIM_MODE_NONE;
 	else
 		aimMode = AIM_MODE_NORMAL;
 
 	DoRobotFrictionAndGravity(theNode, PLAYER_AIR_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, aimMode, false))
+	if (DoPlayerMovementAndCollision(theNode, aimMode, false))
 		goto update;
 
 
-	/*****************/
-	/* SEE IF LANDED */
-	/*****************/
+			/*****************/
+			/* SEE IF LANDED */
+			/*****************/
 
-	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_FALL)						// only bother if still in Fall anim
+	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_FALL)						// only bother if still in Fall anim
 	{
-		if((theNode->StatusBits & STATUS_BIT_ONGROUND) || (gPlayerInfo.distToFloor < 10.0f))
+		if ((theNode->StatusBits & STATUS_BIT_ONGROUND) || (gPlayerInfo.distToFloor < 10.0f))
 		{
 
-			/* DO ANIM AFTER LANDED */
+					/* DO ANIM AFTER LANDED */
 
 			switch(theNode->Skeleton->AnimNum)
 			{
-			case	PLAYER_ANIM_BUMPERCAR:								// check if trigger put us in bumper car
-				break;
+				case	PLAYER_ANIM_BUMPERCAR:								// check if trigger put us in bumper car
+						break;
 
-			default:
-				SetPlayerStandAnim(theNode, 8);						// default to standing when landing
+				default:
+						SetPlayerStandAnim(theNode, 8);						// default to standing when landing
 			}
 
-			if(oldDY < -300.0f)											// if landing fast enough
+			if (oldDY < -300.0f)											// if landing fast enough
 			{
 				PlayEffect3D(EFFECT_METALLAND, &gCoord);					// play hard land sound
 
 						/* MAKE DEFORMATION WAVE */
 
-				if(gLevelNum == LEVEL_NUM_BLOB)
+				if (gLevelNum == LEVEL_NUM_BLOB)
 				{
-					if(gPlayerInfo.distToFloor < 10.0f)						// if on terrain, then deform
+					if (gPlayerInfo.distToFloor < 10.0f)						// if on terrain, then deform
 					{
 						DeformationType		defData;
 
-						defData.type = DEFORMATION_TYPE_RADIALWAVE;
-						defData.amplitude = oldDY * -.08f * gPlayerInfo.scaleRatio;
-						if(defData.amplitude > 1000.0f)
+						defData.type 				= DEFORMATION_TYPE_RADIALWAVE;
+						defData.amplitude 			= oldDY * -.08f * gPlayerInfo.scaleRatio;
+						if (defData.amplitude > 1000.0f)
 							defData.amplitude = 1000.0f;
 
-						defData.radius = 0;
-						defData.speed = 4000;
-						defData.origin.x = gCoord.x;
-						defData.origin.y = gCoord.z;
-						defData.oneOverWaveLength = 1.0f / (400.0f * gPlayerInfo.scaleRatio);
-						defData.radialWidth = 600.0f;
-						defData.decayRate = 200.0f * gPlayerInfo.scaleRatio;
+						defData.radius 				= 0;
+						defData.speed 				= 4000;
+						defData.origin.x			= gCoord.x;
+						defData.origin.y			= gCoord.z;
+						defData.oneOverWaveLength 	= 1.0f / (400.0f * gPlayerInfo.scaleRatio);
+						defData.radialWidth			= 600.0f;
+						defData.decayRate			= 200.0f * gPlayerInfo.scaleRatio;
 						NewSuperTileDeformation(&defData);
 					}
 				}
@@ -1094,7 +1094,7 @@ static void MovePlayerRobot_Fall(ObjNode *theNode)
 	}
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -1105,21 +1105,21 @@ update:
 
 static void MovePlayerRobot_Fall_BottomlessPit(ObjNode *theNode)
 {
-	float	fps = gFramesPerSecondFrac;
+float	fps = gFramesPerSecondFrac;
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;
 	gDelta.x = gDelta.z = 0;
 
-	/* SEE IF TIME FOR DEATH EXIT TRANSITION */
+			/* SEE IF TIME FOR DEATH EXIT TRANSITION */
 
-	if(gDeathTimer > 0.0f)
+	if (gDeathTimer > 0.0f)
 	{
 		gDeathTimer -= fps;					// dec timer
-		if(gDeathTimer <= 0.0f)								// see if time to reset player
+		if (gDeathTimer <= 0.0f)								// see if time to reset player
 			StartDeathExit(0);
 	}
 
-	/* DO MOVEMENT */
+			/* DO MOVEMENT */
 
 	DoRobotFrictionAndGravity(theNode, PLAYER_AIR_FRICTION);
 	gCoord.x += gDelta.x * fps;
@@ -1138,7 +1138,7 @@ static void MovePlayerRobot_Fall_BottomlessPit(ObjNode *theNode)
 
 static void MovePlayerRobot_Thrown(ObjNode *theNode)
 {
-	float	fps = gFramesPerSecondFrac;
+float	fps = gFramesPerSecondFrac;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1153,10 +1153,10 @@ static void MovePlayerRobot_Thrown(ObjNode *theNode)
 	theNode->Rot.x += fps * 10.0f;
 
 
-	/* COLLISION */
+			/* COLLISION */
 
-	HandleCollisions(theNode, CTYPE_MISC | CTYPE_TERRAIN | CTYPE_FENCE, -.6);
-	if(theNode->StatusBits & STATUS_BIT_ONGROUND)								// once on ground then stop
+	HandleCollisions(theNode, CTYPE_MISC|CTYPE_TERRAIN|CTYPE_FENCE, -.6);
+	if (theNode->StatusBits & STATUS_BIT_ONGROUND)								// once on ground then stop
 	{
 		theNode->Rot.x = 0;
 
@@ -1169,7 +1169,7 @@ static void MovePlayerRobot_Thrown(ObjNode *theNode)
 
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 	UpdatePlayer_Robot(theNode);
 }
@@ -1215,15 +1215,15 @@ static void MovePlayerRobot_Drilled(ObjNode *theNode)
 
 static void MovePlayerRobot_Zapped(ObjNode *theNode)
 {
-	if(gLevelNum == LEVEL_NUM_BLOBBOSS)				// if blob boss then must have fallen into water/ground to bob
+	if (gLevelNum == LEVEL_NUM_BLOBBOSS)				// if blob boss then must have fallen into water/ground to bob
 		gCoord.y = GetTerrainY(gCoord.x, gCoord.z);
 
 	theNode->ZappedTimer -= gFramesPerSecondFrac;					// dec timer
-	if(theNode->ZappedTimer <= 0.0f)
+	if (theNode->ZappedTimer <= 0.0f)
 	{
-		/* KILL THE PLAYER */
+			/* KILL THE PLAYER */
 
-		if(gExplodePlayerAfterElectrocute)
+		if (gExplodePlayerAfterElectrocute)
 			KillPlayer(PLAYER_DEATH_TYPE_EXPLODE);
 		else
 			KillPlayer(PLAYER_DEATH_TYPE_DROWN);
@@ -1237,18 +1237,18 @@ static void MovePlayerRobot_Zapped(ObjNode *theNode)
 
 static void MovePlayerRobot_Drowned(ObjNode *theNode)
 {
-	if(gPlayerInfo.waterPatch == -1)						// see if have patch, otherwise use terrain y
+	if (gPlayerInfo.waterPatch == -1)						// see if have patch, otherwise use terrain y
 		gCoord.y = GetTerrainY(gCoord.x, gCoord.z);
 	else
 		gCoord.y = gWaterBBox[gPlayerInfo.waterPatch].max.y;
 
 
-	/* SEE IF END */
+			/* SEE IF END */
 
-	if(gDeathTimer > 0.0f)
+	if (gDeathTimer > 0.0f)
 	{
 		gDeathTimer -= gFramesPerSecondFrac;					// dec timer
-		if(gDeathTimer <= 0.0f)								// see if time to reset player
+		if (gDeathTimer <= 0.0f)								// see if time to reset player
 		{
 			StartDeathExit(0);
 		}
@@ -1262,7 +1262,7 @@ static void MovePlayerRobot_Drowned(ObjNode *theNode)
 
 static void MovePlayerRobot_Flattened(ObjNode *theNode)
 {
-	u_long	wasOnGround = theNode->StatusBits & STATUS_BIT_ONGROUND;
+u_long	wasOnGround = theNode->StatusBits & STATUS_BIT_ONGROUND;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1270,21 +1270,21 @@ static void MovePlayerRobot_Flattened(ObjNode *theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_DEFAULT_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
-	/* PLAY BOUNCE SFX */
+			/* PLAY BOUNCE SFX */
 
-	if((theNode->StatusBits & STATUS_BIT_ONGROUND) && (!wasOnGround))
+	if ((theNode->StatusBits & STATUS_BIT_ONGROUND) && (!wasOnGround))
 	{
-		//		if (gDelta.y > 20.0f)
-		PlayEffect3D(EFFECT_PLAYERCLANG, &gCoord);
+//		if (gDelta.y > 20.0f)
+			PlayEffect3D(EFFECT_PLAYERCLANG, &gCoord);
 	}
 
 
 	gPlayerInfo.knockDownTimer -= gFramesPerSecondFrac;
-	if(gPlayerInfo.knockDownTimer <= 0.0f)
+	if (gPlayerInfo.knockDownTimer <= 0.0f)
 	{
 		SetPlayerStandAnim(theNode, 4);
 		gPlayerInfo.invincibilityTimer = 1.0f;
@@ -1302,16 +1302,16 @@ static void MovePlayerRobot_BellySlide(ObjNode *theNode)
 {
 	theNode->Rot.x = theNode->Rot.z = 0;
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_DEFAULT_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
 	gPlayerInfo.knockDownTimer -= gFramesPerSecondFrac;
-	if((gPlayerInfo.knockDownTimer <= 0.0f) || (theNode->Speed2D <= 0.0f))
+	if ((gPlayerInfo.knockDownTimer <= 0.0f) || (theNode->Speed2D <= 0.0f))
 	{
 		SetPlayerStandAnim(theNode, 3);
 		gPlayerInfo.invincibilityTimer = 1.0f;
@@ -1333,21 +1333,21 @@ static void MovePlayerRobot_Charging(ObjNode *theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
 
-	/* SEE IF DISCHARGE SUPERNOVA */
+			/* SEE IF DISCHARGE SUPERNOVA */
 
-	if(gPlayerInfo.superNovaStatic)						// if this obj exists then we're still charging
+	if (gPlayerInfo.superNovaStatic)						// if this obj exists then we're still charging
 	{
-		if(!GetNeedState(kNeed_Shoot))
+		if (!GetNeedState(kNeed_Shoot))
 		{
 			DischargeSuperNova();							// attempt to discharge it
 		}
 	}
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -1357,7 +1357,7 @@ update:
 
 static void MovePlayerRobot_GotHit(ObjNode *theNode)
 {
-	float	f;
+float	f;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1365,25 +1365,25 @@ static void MovePlayerRobot_GotHit(ObjNode *theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 
-	if(theNode->StatusBits & STATUS_BIT_ONGROUND)
+	if (theNode->StatusBits & STATUS_BIT_ONGROUND)
 		f = PLAYER_HEAVY_FRICTION;
 	else
 		f = PLAYER_AIR_FRICTION;
 	DoRobotFrictionAndGravity(theNode, f);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_REVERSE, true))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_REVERSE, true))
 		goto update;
 
 
-	/* SEE IF DONE */
+			/* SEE IF DONE */
 
-	if(theNode->Skeleton->AnimHasStopped)
+	if (theNode->Skeleton->AnimHasStopped)
 	{
 		gPlayerInfo.invincibilityTimer = 2.0f;
 		SetPlayerStandAnim(theNode, 5);
 	}
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -1401,25 +1401,25 @@ static void MovePlayerRobot_Accordian(ObjNode *theNode)
 	gCoord.y = GetTerrainY(gCoord.x, gCoord.z) + theNode->BBox.min.y;
 
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
-	/* SEE IF DONE */
+			/* SEE IF DONE */
 
 	theNode->AccordianTimer -= gFramesPerSecondFrac;
-	if(theNode->AccordianTimer <= 0.0f)
+	if (theNode->AccordianTimer <= 0.0f)
 	{
 		gPlayerInfo.invincibilityTimer = 1.3f;
 		SetPlayerStandAnim(theNode, 3);
 	}
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -1430,13 +1430,13 @@ update:
 
 static void MovePlayerRobot_Bubble(ObjNode *theNode)
 {
-	float	y;
+float	y;
 
-	/* KEEP FLOATING ABOVE GROUND */
+			/* KEEP FLOATING ABOVE GROUND */
 
 	y = GetTerrainY(gCoord.x, gCoord.z) + 300.0f;
 	gDelta.y = y - gCoord.y;
-	if(gDelta.y > 0.0f)
+	if (gDelta.y > 0.0f)
 		gDelta.y *= 2.0f;					// float up faster than float down
 
 
@@ -1445,14 +1445,14 @@ static void MovePlayerRobot_Bubble(ObjNode *theNode)
 	DoPlayerMovementAndCollision_Bubble(theNode);
 
 
-	/* UPDATE ME */
+			/* UPDATE ME */
 
 	UpdatePlayer_Robot(theNode);
 
 
-	/* UPDATE BUBBLE */
+		/* UPDATE BUBBLE */
 
-	if(gSoapBubble)
+	if (gSoapBubble)
 	{
 		gSoapBubble->Coord = gCoord;
 		UpdateObjectTransforms(gSoapBubble);
@@ -1471,13 +1471,13 @@ static void MovePlayerRobot_Drink(ObjNode *theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_DEFAULT_FRICTION);
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
-	/* SEE IF DONE */
+			/* SEE IF DONE */
 
-	if(theNode->Skeleton->AnimHasStopped)
+	if (theNode->Skeleton->AnimHasStopped)
 	{
 		gPlayerInfo.growMode = GROWTH_MODE_GROW;
 		gPlayerInfo.giantTimer = 12.0f;
@@ -1494,7 +1494,7 @@ update:
 
 static void MovePlayerRobot_RideZip(ObjNode *theNode)
 {
-	float	r = theNode->Rot.y;
+float	r = theNode->Rot.y;
 
 
 	gCoord = gCurrentZip->Coord;		// get pully coord
@@ -1514,11 +1514,11 @@ static void MovePlayerRobot_ClimbInto(ObjNode *theNode)
 {
 	theNode->Skeleton->AnimSpeed = 1.6;
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	gDelta.x = gDelta.y = gDelta.z = 0.0f;
-	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
@@ -1532,9 +1532,9 @@ update:
 
 static void MovePlayerRobot_ShotFromCannon(ObjNode *theNode)
 {
-	float	fps = gFramesPerSecondFrac;
+float	fps = gFramesPerSecondFrac;
 
-	/* MOVE PLAYER */
+			/* MOVE PLAYER */
 
 	gDelta.y -= 500.0f * fps;
 
@@ -1542,11 +1542,11 @@ static void MovePlayerRobot_ShotFromCannon(ObjNode *theNode)
 	gCoord.y += gDelta.y * fps;
 	gCoord.z += gDelta.z * fps;
 
-	theNode->Rot.x -= PI / 7 * fps;
+	theNode->Rot.x -= PI/7 * fps;
 
-	/* SEE IF HIT GROUND */
+			/* SEE IF HIT GROUND */
 
-	if((gCoord.y + theNode->BBox.min.y) <= GetTerrainY(gCoord.x, gCoord.z))
+	if ((gCoord.y + theNode->BBox.min.y) <= GetTerrainY(gCoord.x, gCoord.z))
 	{
 		SetSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_BELLYSLIDE);
 		gPlayerInfo.knockDownTimer = 1.0f;
@@ -1555,7 +1555,7 @@ static void MovePlayerRobot_ShotFromCannon(ObjNode *theNode)
 
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 	UpdatePlayer_Robot(theNode);
 }
@@ -1568,7 +1568,7 @@ static void MovePlayerRobot_BumperCar(ObjNode *theNode)
 {
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 	AlignPlayerInBumperCar(theNode);
 	UpdatePlayer_Robot(theNode);
@@ -1580,7 +1580,7 @@ static void MovePlayerRobot_RocketSled(ObjNode *theNode)
 {
 
 
-	/* UPDATE IT */
+			/* UPDATE IT */
 
 	AlignPlayerInRocketSled(theNode);
 	UpdatePlayer_Robot(theNode);
@@ -1594,76 +1594,76 @@ static void MovePlayerRobot_RocketSled(ObjNode *theNode)
 
 void UpdatePlayer_Robot(ObjNode *theNode)
 {
-	float fps = gFramesPerSecondFrac;
+float fps = gFramesPerSecondFrac;
 
-	/* VERIFY BOTTOMLESS PIT */
+			/* VERIFY BOTTOMLESS PIT */
 
-	if(gLevelNum == LEVEL_NUM_CLOUD)
+	if (gLevelNum == LEVEL_NUM_CLOUD)
 	{
-		if((gCoord.y + theNode->BBox.min.y) < (GetTerrainY2(gCoord.x, gCoord.z) - 30.0f))		// if player is below terrain's real height
+		if ((gCoord.y + theNode->BBox.min.y) < (GetTerrainY2(gCoord.x, gCoord.z) - 30.0f))		// if player is below terrain's real height
 		{
-			if(GetTerrainY(gCoord.x, gCoord.z) == BOTTOMLESS_PIT_Y)							//  and if this is a bottomless pit zone
+			if (GetTerrainY(gCoord.x, gCoord.z) == BOTTOMLESS_PIT_Y)							//  and if this is a bottomless pit zone
 				KillPlayer(PLAYER_DEATH_TYPE_FALL);
 		}
 	}
 
 
-	/* VERIFY ANIM INFO */
+		/* VERIFY ANIM INFO */
 
 	switch(theNode->Skeleton->AnimNum)
 	{
-	case	PLAYER_ANIM_STANDWITHGUN:
-		if(!gPlayerInfo.holdingGun)											// verify using correct stand anim
-			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STAND, 6.0);
-		break;
+		case	PLAYER_ANIM_STANDWITHGUN:
+				if (!gPlayerInfo.holdingGun)											// verify using correct stand anim
+					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STAND, 6.0);
+				break;
 
-	case	PLAYER_ANIM_STAND:
-		if(gPlayerInfo.holdingGun)
-			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STANDWITHGUN, 6.0);
-		break;
+		case	PLAYER_ANIM_STAND:
+				if (gPlayerInfo.holdingGun)
+					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STANDWITHGUN, 6.0);
+				break;
 
-	case	PLAYER_ANIM_WALKWITHGUN:
-		if(!gPlayerInfo.holdingGun)											// verify using correct walk anim
-			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALK, 9.0);
-		break;
+		case	PLAYER_ANIM_WALKWITHGUN:
+				if (!gPlayerInfo.holdingGun)											// verify using correct walk anim
+					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALK, 9.0);
+				break;
 
-	case	PLAYER_ANIM_WALK:
-		if(gPlayerInfo.holdingGun)
-			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALKWITHGUN, 9.0);
-		break;
+		case	PLAYER_ANIM_WALK:
+				if (gPlayerInfo.holdingGun)
+					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALKWITHGUN, 9.0);
+				break;
 
 	}
 
 
-	/* UPDATE SPECIAL COLLISION INFO */
+		/* UPDATE SPECIAL COLLISION INFO */
 
 	switch(theNode->Skeleton->AnimNum)
 	{
-	case	PLAYER_ANIM_ACCORDIAN:
-	case	PLAYER_ANIM_FLATTENED:
-	case	PLAYER_ANIM_DROWNED:
-	case	PLAYER_ANIM_GOTHIT:
-		theNode->TopOff = theNode->BBox.max.y * .7f;
-		break;
+		case	PLAYER_ANIM_ACCORDIAN:
+		case	PLAYER_ANIM_FLATTENED:
+		case	PLAYER_ANIM_DROWNED:
+		case	PLAYER_ANIM_GOTHIT:
+				theNode->TopOff = theNode->BBox.max.y * .7f;
+				break;
 
-	default:
-		theNode->TopOff = gObjectGroupBBoxList[MODEL_GROUP_SKELETONBASE + SKELETON_TYPE_OTTO][0].max.y * theNode->Scale.y * .7f;
-		break;
+		default:
+				theNode->TopOff = gObjectGroupBBoxList[MODEL_GROUP_SKELETONBASE+SKELETON_TYPE_OTTO][0].max.y * theNode->Scale.y * .7f;
+				break;
 	}
 
 
-	/* UPDATE OBJECT AS LONG AS NOT BEING MATRIX CONTROLLED */
+		/* UPDATE OBJECT AS LONG AS NOT BEING MATRIX CONTROLLED */
 
 	switch(theNode->Skeleton->AnimNum)
 	{
-	case	PLAYER_ANIM_GRABBED:
-	case	PLAYER_ANIM_GRABBED2:
-	case	PLAYER_ANIM_GRABBEDBYSTRONGMAN:
-	case	PLAYER_ANIM_ROCKETSLED:
-		break;
+		case	PLAYER_ANIM_GRABBED:
+		case	PLAYER_ANIM_GRABBED2:
+		case	PLAYER_ANIM_GRABBEDBYSTRONGMAN:
+		case	PLAYER_ANIM_ROCKETSLED:
+				break;
 
-	default:
-		UpdateObject(theNode);
+		default:
+				UpdateObject(theNode);
 	}
 
 	gPlayerInfo.coord = gCoord;				// update player coord
@@ -1674,52 +1674,52 @@ void UpdatePlayer_Robot(ObjNode *theNode)
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);
 	theNode->Speed3D = CalcVectorLength(&gDelta);
 
-	if(theNode->Speed2D < gTargetMaxSpeed)					// if we're less than the target, then just reset current to target
+	if (theNode->Speed2D < gTargetMaxSpeed)					// if we're less than the target, then just reset current to target
 		gCurrentMaxSpeed = gTargetMaxSpeed;
 	else
-		if(gCurrentMaxSpeed > gTargetMaxSpeed)					// see if in overdrive, so readjust currnet
+	if (gCurrentMaxSpeed > gTargetMaxSpeed)					// see if in overdrive, so readjust currnet
+	{
+		if (theNode->Speed2D < gCurrentMaxSpeed)			// we're slower than Current, so adjust current down to us
 		{
-			if(theNode->Speed2D < gCurrentMaxSpeed)			// we're slower than Current, so adjust current down to us
-			{
-				gCurrentMaxSpeed = theNode->Speed2D;
-			}
+			gCurrentMaxSpeed = theNode->Speed2D;
 		}
+	}
 
-	/* UPDATE SPARKLES & FLAME */
+			/* UPDATE SPARKLES & FLAME */
 
 	UpdatePlayerSparkles(theNode);
 
-	if(gPlayerInfo.burnTimer > 0.0f)
+	if (gPlayerInfo.burnTimer > 0.0f)
 	{
 		gPlayerInfo.burnTimer -= fps;
-		BurnSkeleton(theNode, 40.0f * gPlayerInfo.scaleRatio);
+		BurnSkeleton(theNode,40.0f * gPlayerInfo.scaleRatio);
 	}
 
 
 
 
-	/****************/
-	/* UPDATE HANDS */
-	/****************/
+			/****************/
+			/* UPDATE HANDS */
+			/****************/
 
 	UpdateRobotHands(theNode);
 
 
-	/* CHECK FOR ACCIDENTAL SUPERNOVA DISCHARGE */
+			/* CHECK FOR ACCIDENTAL SUPERNOVA DISCHARGE */
 
-	if((theNode->Skeleton->AnimNum != PLAYER_ANIM_CHARGING) &&		// if we are not charging but we have a static object
+	if ((theNode->Skeleton->AnimNum != PLAYER_ANIM_CHARGING) &&		// if we are not charging but we have a static object
 		(gPlayerInfo.superNovaStatic != nil))
 	{
 		DischargeSuperNova();
 	}
 
 
-	/* CHECK INV TIMER */
+		/* CHECK INV TIMER */
 
 	gPlayerInfo.invincibilityTimer -= fps;
 
 
-	if(theNode->StatusBits & STATUS_BIT_ONGROUND)		// if on ground then reset jump jet
+	if (theNode->StatusBits & STATUS_BIT_ONGROUND)		// if on ground then reset jump jet
 		gResetJumpJet = true;
 }
 
@@ -1728,15 +1728,15 @@ void UpdatePlayer_Robot(ObjNode *theNode)
 
 void UpdateRobotHands(ObjNode *theNode)
 {
-	ObjNode *lhand, *rhand;
-	Boolean	holdingGun;
-	int		weaponType;
+ObjNode	*lhand,*rhand;
+Boolean	holdingGun;
+int		weaponType;
 
-	/****************************/
-	/* DETERMINE IF HOLDING GUN */
-	/****************************/
+		/****************************/
+		/* DETERMINE IF HOLDING GUN */
+		/****************************/
 
-	if((theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON) && (!theNode->ChangeWeapon))	// see if still holding old gun during weapon change
+	if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON) && (!theNode->ChangeWeapon))	// see if still holding old gun during weapon change
 	{
 		weaponType = gPlayerInfo.oldWeaponType;				// use old weapon Type
 		holdingGun = gPlayerInfo.wasHoldingGun;				// use old gun flag
@@ -1745,81 +1745,81 @@ void UpdateRobotHands(ObjNode *theNode)
 	{
 		holdingGun = gPlayerInfo.holdingGun;
 		weaponType = gPlayerInfo.currentWeaponType;
-		if(weaponType >= WEAPON_TYPE_FIST)							// verify it while we're here
+		if (weaponType >= WEAPON_TYPE_FIST)							// verify it while we're here
 			holdingGun = gPlayerInfo.holdingGun = false;
 	}
 
-	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_BUMPERCAR)		// don't show gun while driving bumper car
+	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_BUMPERCAR)		// don't show gun while driving bumper car
 		holdingGun = false;
 	else
-		if(theNode->Skeleton->AnimNum == PLAYER_ANIM_BUBBLE)			// don't show gun while riding bubble
-			holdingGun = false;
+	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_BUBBLE)			// don't show gun while riding bubble
+		holdingGun = false;
 
-	/*****************************/
-	/* UPDATE GEOMETRY FOR HANDS */
-	/*****************************/
+			/*****************************/
+			/* UPDATE GEOMETRY FOR HANDS */
+			/*****************************/
 
 	lhand = gPlayerInfo.leftHandObj;						// get hand objects
 	rhand = gPlayerInfo.rightHandObj;
 
 	lhand->ColorFilter.a = rhand->ColorFilter.a = theNode->ColorFilter.a;	// match alpha fades
 
-	if(rhand && lhand)										// only update if both hands are legit
+	if (rhand && lhand)										// only update if both hands are legit
 	{
 
 		switch(theNode->Skeleton->AnimNum)
 		{
-			/* OPEN HANDS */
+					/* OPEN HANDS */
 
-		case	PLAYER_ANIM_STAND:
-		case	PLAYER_ANIM_STANDWITHGUN:
-		case	PLAYER_ANIM_JUMP:
-		case	PLAYER_ANIM_FALL:
-		case	PLAYER_ANIM_BUBBLE:
-		case	PLAYER_ANIM_SITONLEDGE:
-		case	PLAYER_ANIM_DRILLED:
-			if(rhand->Type != GLOBAL_ObjType_OttoRightHand)
-			{
-				rhand->Type = GLOBAL_ObjType_OttoRightHand;
-				ResetDisplayGroupObject(rhand);
-			}
+			case	PLAYER_ANIM_STAND:
+			case	PLAYER_ANIM_STANDWITHGUN:
+			case	PLAYER_ANIM_JUMP:
+			case	PLAYER_ANIM_FALL:
+			case	PLAYER_ANIM_BUBBLE:
+			case	PLAYER_ANIM_SITONLEDGE:
+			case	PLAYER_ANIM_DRILLED:
+					if (rhand->Type != GLOBAL_ObjType_OttoRightHand)
+					{
+						rhand->Type = GLOBAL_ObjType_OttoRightHand;
+						ResetDisplayGroupObject(rhand);
+					}
 
-			if(!holdingGun)
-			{
-				if(lhand->Type != GLOBAL_ObjType_OttoLeftHand)
-				{
-					lhand->Type = GLOBAL_ObjType_OttoLeftHand;
-					ResetDisplayGroupObject(lhand);
-				}
-			}
-			break;
+					if (!holdingGun)
+					{
+						if (lhand->Type != GLOBAL_ObjType_OttoLeftHand)
+						{
+							lhand->Type = GLOBAL_ObjType_OttoLeftHand;
+							ResetDisplayGroupObject(lhand);
+						}
+					}
+					break;
 
 
-			/* FISTS */
+					/* FISTS */
 
-		default:
-			if(rhand->Type != GLOBAL_ObjType_OttoRightFist)
-			{
-				rhand->Type = GLOBAL_ObjType_OttoRightFist;
-				ResetDisplayGroupObject(rhand);
-			}
+			default:
+					if (rhand->Type != GLOBAL_ObjType_OttoRightFist)
+					{
+						rhand->Type = GLOBAL_ObjType_OttoRightFist;
+						ResetDisplayGroupObject(rhand);
+					}
 
-			if(!holdingGun)
-			{
-				if(lhand->Type != GLOBAL_ObjType_OttoLeftFist)
-				{
-					lhand->Type = GLOBAL_ObjType_OttoLeftFist;
-					ResetDisplayGroupObject(lhand);
-				}
-			}
-			break;
+					if (!holdingGun)
+					{
+						if (lhand->Type != GLOBAL_ObjType_OttoLeftFist)
+						{
+							lhand->Type = GLOBAL_ObjType_OttoLeftFist;
+							ResetDisplayGroupObject(lhand);
+						}
+					}
+					break;
 		}
 
-		/* GUN IN LEFT HAND */
+				/* GUN IN LEFT HAND */
 
-		if(holdingGun)
+		if (holdingGun)
 		{
-			if(lhand->Type != (GLOBAL_ObjType_PulseGunHand + weaponType))
+			if (lhand->Type != (GLOBAL_ObjType_PulseGunHand + weaponType))
 			{
 				lhand->Type = GLOBAL_ObjType_PulseGunHand + weaponType;
 				ResetDisplayGroupObject(lhand);
@@ -1827,7 +1827,7 @@ void UpdateRobotHands(ObjNode *theNode)
 		}
 
 
-		/* UPDATE HAND MATRICES */
+			/* UPDATE HAND MATRICES */
 
 		FindJointFullMatrix(theNode, PLAYER_JOINT_LEFTHAND, &lhand->BaseTransformMatrix);
 		SetObjectTransformMatrix(lhand);
@@ -1854,57 +1854,57 @@ void UpdateRobotHands(ObjNode *theNode)
 
 void UpdatePlayerMotionBlur(ObjNode *theNode)
 {
-	int		v, i;
-	static OGLColorRGBA color = { 0.6f, 0.6f, 1.0f, PLAYER_VAPOR_ALPHA };
-	static OGLColorRGBA color2 = { 0.4f, 1.0f, 0.4f, PLAYER_VAPOR_ALPHA };
-	OGLPoint3D	p;
-	OGLVector3D	playerVec, viewVec;
-	float		dot;
+int		v,i;
+static OGLColorRGBA color	= { 0.6f, 0.6f, 1.0f, PLAYER_VAPOR_ALPHA };
+static OGLColorRGBA color2	= { 0.4f, 1.0f, 0.4f, PLAYER_VAPOR_ALPHA };
+OGLPoint3D	p;
+OGLVector3D	playerVec,viewVec;
+float		dot;
 
 
-	/*************************/
-	/* SEE IF SHOULD TO BLUR */
-	/*************************/
+			/*************************/
+			/* SEE IF SHOULD TO BLUR */
+			/*************************/
 
-	if(theNode->Skeleton->AnimNum != PLAYER_ANIM_JUMPJET)													// always blur when jump-jetting
+	if (theNode->Skeleton->AnimNum != PLAYER_ANIM_JUMPJET)													// always blur when jump-jetting
 	{
-		if(theNode->Speed3D < PLAYER_VAPOR_THRESHOLD)				// only add trail if going fast
+		if (theNode->Speed3D < PLAYER_VAPOR_THRESHOLD)				// only add trail if going fast
 			return;
 
-		/* DONT DO BLUR IF PLAYER IS MOVING AWAY FROM CAMERA */
+			/* DONT DO BLUR IF PLAYER IS MOVING AWAY FROM CAMERA */
 
 		FastNormalizeVector(theNode->Delta.x, theNode->Delta.y, theNode->Delta.z, &playerVec);					// calc player motion vector
 		FastNormalizeVector(theNode->Coord.x - gGameViewInfoPtr->cameraPlacement.cameraLocation.x,				// calc vector from camera to player
-			theNode->Coord.y - gGameViewInfoPtr->cameraPlacement.cameraLocation.y,
-			theNode->Coord.z - gGameViewInfoPtr->cameraPlacement.cameraLocation.z,
-			&viewVec);
+							theNode->Coord.y - gGameViewInfoPtr->cameraPlacement.cameraLocation.y,
+							theNode->Coord.z - gGameViewInfoPtr->cameraPlacement.cameraLocation.z,
+							&viewVec);
 
 		dot = OGLVector3D_Dot(&playerVec, &viewVec);															// calc dot product to determine angle
-		if((dot > .9f) || (dot < -.9f))
+		if ((dot > .9f) || (dot < -.9f))
 			return;
 	}
 
 
-	/*******************/
-	/* UPDATE THE BLUR */
-	/*******************/
+			/*******************/
+			/* UPDATE THE BLUR */
+			/*******************/
 
-	for(v = 0; v < theNode->Skeleton->skeletonDefinition->NumBones; v++)
+	for (v = 0; v< theNode->Skeleton->skeletonDefinition->NumBones; v++)
 	{
 		FindCoordOfJoint(theNode, v, &p);
 
 		i = theNode->VaporTrails[v];							// get vaport trail #
 
-		if(VerifyVaporTrail(i, theNode, v))
+		if (VerifyVaporTrail(i, theNode, v))
 		{
-			if(v == 1)											// head has white trail
+			if (v == 1)											// head has white trail
 				AddToVaporTrail(&theNode->VaporTrails[v], &p, &color2);
 			else
 				AddToVaporTrail(&theNode->VaporTrails[v], &p, &color);
 		}
 		else
 		{
-			if(theNode->Speed3D > (PLAYER_VAPOR_THRESHOLD * 1.2f))				// only start new vapor if above the threshold by a good margin to avoid "popping"
+			if (theNode->Speed3D > (PLAYER_VAPOR_THRESHOLD * 1.2f))				// only start new vapor if above the threshold by a good margin to avoid "popping"
 				theNode->VaporTrails[v] = CreateNewVaporTrail(theNode, v, VAPORTRAIL_TYPE_COLORSTREAK, &p, &color, 1.0, 4.0, 20.0);
 		}
 	}
@@ -1916,9 +1916,9 @@ void UpdatePlayerMotionBlur(ObjNode *theNode)
 
 static void UpdatePlayerAutoAim(ObjNode *player)
 {
-	float	tx, tz;
+float	tx,tz;
 
-	if(gPlayerInfo.autoAimTimer <= 0.0f)
+	if (gPlayerInfo.autoAimTimer <= 0.0f)
 		return;
 
 	gPlayerInfo.autoAimTimer -= gFramesPerSecondFrac;			// dec timer
@@ -1941,15 +1941,15 @@ static void UpdatePlayerAutoAim(ObjNode *player)
 
 static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Boolean useBBoxForTerrain)
 {
-	float				fps = gFramesPerSecondFrac, oldFPS, oldFPSFrac, terrainY;
-	OGLPoint3D			oldCoord;
-	//OGLVector2D			aimVec, deltaVec, accVec;
-	//OGLMatrix3x3		m;
-	static OGLPoint2D origin = { 0,0 };
-	int					numPasses, pass;
-	Boolean				killed = false;
+float				fps = gFramesPerSecondFrac,oldFPS,oldFPSFrac,terrainY;
+OGLPoint3D			oldCoord;
+//OGLVector2D			aimVec,deltaVec, accVec;
+//OGLMatrix3x3		m;
+static OGLPoint2D origin = {0,0};
+int					numPasses,pass;
+Boolean				killed = false;
 
-	if(gPlayerInfo.analogControlX || gPlayerInfo.analogControlZ || gPlayerInfo.strafeControlX)	// if player is attempting some control then reset this timer
+	if (gPlayerInfo.analogControlX || gPlayerInfo.analogControlZ || gPlayerInfo.strafeControlX)	// if player is attempting some control then reset this timer
 	{
 		gTimeSinceLastThrust = 0;
 		gForceCameraAlignment = false;								// now that player is moving us, dont force auto-align
@@ -1961,13 +1961,13 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 	/* DO PLAYER-RELATIVE CONTROLS */
 	/*******************************/
 
-	if(true) // (Gives better mouse control?) Seems to prevent player from turning when colliding 
+	if (true) // (Gives better mouse control?) Seems to prevent player from turning when colliding 
 	{
 		float	sens;
 
 		// analogControlX is mouse only now
 		sens = gPlayerInfo.analogControlX * fps * CONTROL_SENSITIVITY_PR_TURN;
-
+		
 		sens *= 0.5f; // sensitivity for turning camera (horizontally)
 
 		theNode->Rot.y -= sens; // Set rotate view (view follows robot rot) with analogControl (mouse)
@@ -1976,17 +1976,17 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 		float	strafe = 0.0f, movement = 0.0f;
 
 		// We are using the A or D keys (strafing):
-		if(gPlayerInfo.strafeControlX) {
+		if (gPlayerInfo.strafeControlX) {
 			// We are only strafing (no forward nor backward):
-			if(gPlayerInfo.analogControlZ == 0) {
+			if (gPlayerInfo.analogControlZ == 0) {
 				strafe = theNode->Rot.y + PI / 2;
 			}
 			// We are moving forward:
-			else if(gPlayerInfo.analogControlZ < 0) {
+			else if (gPlayerInfo.analogControlZ < 0) {
 				strafe = theNode->Rot.y - sin(gPlayerInfo.strafeControlX);
 			}
 			// We are moving backward:
-			else if(gPlayerInfo.analogControlZ > 0) {
+			else if (gPlayerInfo.analogControlZ > 0) {
 				strafe = theNode->Rot.y + sin(gPlayerInfo.strafeControlX);
 			}
 		}
@@ -1999,7 +1999,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 		theNode->AccelVector.y = cos(strafe);
 
 
-		if(!gPlayerInfo.analogControlZ) {
+		if (!gPlayerInfo.analogControlZ) {
 			movement = gPlayerInfo.strafeControlX;
 		}
 		else {
@@ -2007,7 +2007,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 		}
 
 
-		if(theNode->StatusBits & STATUS_BIT_ONGROUND)
+		if (theNode->StatusBits & STATUS_BIT_ONGROUND)
 		{
 			gDelta.x += theNode->AccelVector.x * ((CONTROL_SENSITIVITY_PR * movement) * (1.1f - gPlayerSlipperyFactor) * fps);
 			gDelta.z += theNode->AccelVector.y * ((CONTROL_SENSITIVITY_PR * movement) * (1.1f - gPlayerSlipperyFactor) * fps);
@@ -2095,7 +2095,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 	/* CALC SPEED */
 
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);					// calc 2D speed value
-	if((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
+	if ((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
 	{
 	}
 	else
@@ -2104,7 +2104,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 		gDelta.x = gDelta.z = 0;
 	}
 
-	if(theNode->Speed2D > gCurrentMaxSpeed)						// see if limit top speed
+	if (theNode->Speed2D > gCurrentMaxSpeed)						// see if limit top speed
 	{
 		float	tweak;
 
@@ -2134,7 +2134,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 
 	fps = gFramesPerSecondFrac;
 
-	for(pass = 0; pass < numPasses; pass++)
+	for (pass = 0; pass < numPasses; pass++)
 	{
 		float	dx, dy, dz;
 
@@ -2147,9 +2147,9 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 		dy = gDelta.y;
 		dz = gDelta.z;
 
-		if(theNode->MPlatform)						// see if factor in moving platform
+		if (theNode->MPlatform)						// see if factor in moving platform
 		{
-			ObjNode *plat = theNode->MPlatform;
+			ObjNode* plat = theNode->MPlatform;
 			dx += plat->Delta.x;
 			dy += plat->Delta.y;
 			dz += plat->Delta.z;
@@ -2166,7 +2166,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 		/* DO OBJECT COLLISION DETECT */
 		/******************************/
 
-		if(DoRobotCollisionDetect(theNode, useBBoxForTerrain))
+		if (DoRobotCollisionDetect(theNode, useBBoxForTerrain))
 			killed = true;
 
 
@@ -2206,17 +2206,17 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 
 static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 {
-	float				fps = gFramesPerSecondFrac, oldFPS, oldFPSFrac;
-	OGLVector3D			accVec;
-	OGLMatrix4x4		m;
-	static const OGLVector3D up = { 0,1,0 };
-	Boolean				killed = false;
-	OGLPoint3D			oldCoord;
-	int					numPasses, pass;
+float				fps = gFramesPerSecondFrac,oldFPS,oldFPSFrac;
+OGLVector3D			accVec;
+OGLMatrix4x4		m;
+static const OGLVector3D up = {0,1,0};
+Boolean				killed = false;
+OGLPoint3D			oldCoord;
+int					numPasses,pass;
 
 
 
-	/* SET INITIAL INFO */
+				/* SET INITIAL INFO */
 
 	theNode->AccelVector.x = theNode->AccelVector.y = 0;							// player has no acceleration control of jump-jet
 
@@ -2225,15 +2225,15 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 	theNode->Rot.y -= gPlayerInfo.analogControlX * 1.5f * fps;
 
 
-	/* CALC MOTION VECTOR BASED ON AIM OF JUMP-JET ANIM */
+		/* CALC MOTION VECTOR BASED ON AIM OF JUMP-JET ANIM */
 
-	FindJointFullMatrix(theNode, PLAYER_JOINT_BASE, &m);							// get matrix from skeleton joint
+	FindJointFullMatrix(theNode,  PLAYER_JOINT_BASE, &m);							// get matrix from skeleton joint
 	OGLVector3D_Transform(&up, &m, &accVec);										// calculate a motion vector
 
 				/* CALC SPEED */
 
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);					// calc 2D speed value
-	if((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))	// check for weird NaN bug
+	if ((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))	// check for weird NaN bug
 	{
 	}
 	else
@@ -2243,16 +2243,16 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 	}
 
 
-	/*****************************************/
-	/* PART 1: MOVE AND COLLIDE IN MULTIPASS */
-	/*****************************************/
+		/*****************************************/
+		/* PART 1: MOVE AND COLLIDE IN MULTIPASS */
+		/*****************************************/
 
-	/* SUB-DIVIDE DELTA INTO MANAGABLE LENGTHS */
+		/* SUB-DIVIDE DELTA INTO MANAGABLE LENGTHS */
 
 	oldFPS = gFramesPerSecond;											// remember what fps really is
 	oldFPSFrac = gFramesPerSecondFrac;
 
-	numPasses = (theNode->Speed2D * oldFPSFrac) * (1.0f / DELTA_SUBDIV);	// calc how many subdivisions to create
+	numPasses = (theNode->Speed2D*oldFPSFrac) * (1.0f / DELTA_SUBDIV);	// calc how many subdivisions to create
 	numPasses++;
 
 	gFramesPerSecondFrac *= 1.0f / (float)numPasses;					// adjust frame rate during motion and collision
@@ -2260,9 +2260,9 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 
 	fps = gFramesPerSecondFrac;
 
-	for(pass = 0; pass < numPasses; pass++)
+	for (pass = 0; pass < numPasses; pass++)
 	{
-		float	dx, dy, dz;
+		float	dx,dy,dz;
 
 		oldCoord = gCoord;								// remember starting coord
 
@@ -2274,17 +2274,17 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 		dz = gDelta.z;
 
 
-		/* MOVE IT */
+					/* MOVE IT */
 
-		if(theNode->JumpJetEnginesOff)
+		if (theNode->JumpJetEnginesOff)
 		{
 			gPlayerInfo.jumpJetSpeed -= JUMP_JET_DECELERATION * fps;					// decelerate jump jet speed
-			if(gPlayerInfo.jumpJetSpeed < 0.0f)
+			if (gPlayerInfo.jumpJetSpeed < 0.0f)
 				gPlayerInfo.jumpJetSpeed = 0;
 		}
 		else
 		{
-			if(theNode->Skeleton->AnimNum == PLAYER_ANIM_GIANTJUMPJET)
+			if (theNode->Skeleton->AnimNum == PLAYER_ANIM_GIANTJUMPJET)
 				gPlayerInfo.jumpJetSpeed += JUMP_JET_ACCELERATION_GIANT * fps;					// accelerate jump jet speed as giant
 			else
 				gPlayerInfo.jumpJetSpeed += JUMP_JET_ACCELERATION * fps;					// accelerate jump jet speed
@@ -2294,14 +2294,14 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 		gDelta.y = accVec.y * gPlayerInfo.jumpJetSpeed;
 		gDelta.z = accVec.z * gPlayerInfo.jumpJetSpeed;
 
-		gCoord.x += dx * fps;
-		gCoord.y += dy * fps;
-		gCoord.z += dz * fps;
+		gCoord.x += dx*fps;
+		gCoord.y += dy*fps;
+		gCoord.z += dz*fps;
 
 
-		/******************************/
-		/* DO OBJECT COLLISION DETECT */
-		/******************************/
+					/******************************/
+					/* DO OBJECT COLLISION DETECT */
+					/******************************/
 
 		killed = DoRobotCollisionDetect(theNode, true);
 
@@ -2311,9 +2311,9 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 	gFramesPerSecond = oldFPS;										// restore real FPS values
 	gFramesPerSecondFrac = oldFPSFrac;
 
-	/*************************/
-	/* CHECK FENCE COLLISION */
-	/*************************/
+				/*************************/
+				/* CHECK FENCE COLLISION */
+				/*************************/
 
 	DoFenceCollision(theNode);
 
@@ -2321,18 +2321,18 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 
 
 
-	/******************************/
-	/* DO JUMP-JET FIST COLLISION */
-	/******************************/
+				/******************************/
+				/* DO JUMP-JET FIST COLLISION */
+				/******************************/
 
-	if(!killed)
+	if (!killed)
 	{
-		static const OGLPoint3D fistOff = { 0,-50,0 };
-		OGLPoint3D	fistCoord1, fistCoord2;
+		static const OGLPoint3D fistOff = {0,-50,0};
+		OGLPoint3D	fistCoord1,fistCoord2;
 		int			i;
-		ObjNode *hitObj;
+		ObjNode		*hitObj;
 
-		/* CALC COORD TO TEST */
+					/* CALC COORD TO TEST */
 
 		FindCoordOnJoint(theNode, PLAYER_JOINT_RIGHTHAND, &fistOff, &fistCoord1);			// calc coord of fists
 		FindCoordOnJoint(theNode, PLAYER_JOINT_LEFTHAND, &fistOff, &fistCoord2);
@@ -2341,17 +2341,17 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 		fistCoord1.y = (fistCoord1.y + fistCoord2.y) * .5f;
 		fistCoord1.z = (fistCoord1.z + fistCoord2.z) * .5f;
 
-		/* SEE IF HIT ANYTHING */
+						/* SEE IF HIT ANYTHING */
 
-		if(DoSimpleBoxCollision(fistCoord1.y + 30.0f, fistCoord1.y - 30.0f, fistCoord1.x - 30.0f, fistCoord1.x + 30.0f,
-			fistCoord1.z + 30.0f, fistCoord1.z - 30.0f, CTYPE_MISC | CTYPE_ENEMY))
+		if (DoSimpleBoxCollision(fistCoord1.y + 30.0f, fistCoord1.y - 30.0f, fistCoord1.x - 30.0f, fistCoord1.x + 30.0f,
+								fistCoord1.z + 30.0f, fistCoord1.z - 30.0f, CTYPE_MISC|CTYPE_ENEMY))
 		{
-			for(i = 0; i < gNumCollisions; i++)										// scan hits for a handler
+			for (i = 0; i < gNumCollisions; i++)										// scan hits for a handler
 			{
 				hitObj = gCollisionList[i].objectPtr;									// get hit ObjNode
-				if(hitObj)
+				if (hitObj)
 				{
-					if(hitObj->HitByJumpJetHandler)									// see if there is a handler
+					if (hitObj->HitByJumpJetHandler)									// see if there is a handler
 						(hitObj->HitByJumpJetHandler)(hitObj);							// call the handler
 				}
 			}
@@ -2369,18 +2369,18 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 
 static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
 {
-	float				fps = gFramesPerSecondFrac;
-	OGLVector2D			aimVec, deltaVec, accVec;
-	OGLMatrix3x3		m;
-	static OGLPoint2D origin = { 0,0 };
-	Boolean				hit = false;
-	float				oldRadius;
+float				fps = gFramesPerSecondFrac;
+OGLVector2D			aimVec,deltaVec, accVec;
+OGLMatrix3x3		m;
+static OGLPoint2D origin = {0,0};
+Boolean				hit = false;
+float				oldRadius;
 
-	/*******************************/
-	/* DO PLAYER-RELATIVE CONTROLS */
-	/*******************************/
+				/*******************************/
+				/* DO PLAYER-RELATIVE CONTROLS */
+				/*******************************/
 
-	if(gGamePrefs.playerRelControls)
+	if (gGamePrefs.playerRelControls)
 	{
 		float	r;
 
@@ -2389,7 +2389,7 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
 		theNode->AccelVector.x = sin(r);
 		theNode->AccelVector.y = cos(r);
 
-		if(theNode->StatusBits & STATUS_BIT_ONGROUND)
+		if (theNode->StatusBits & STATUS_BIT_ONGROUND)
 		{
 			gDelta.x += theNode->AccelVector.x * (CONTROL_SENSITIVITY_PR * gPlayerInfo.analogControlZ) * (1.1f - gPlayerSlipperyFactor);
 			gDelta.z += theNode->AccelVector.y * (CONTROL_SENSITIVITY_PR * gPlayerInfo.analogControlZ) * (1.1f - gPlayerSlipperyFactor);
@@ -2402,15 +2402,15 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
 
 	}
 
-	/*******************************/
-	/* DO CAMERA-RELATIVE CONTROLS */
-	/*******************************/
+				/*******************************/
+				/* DO CAMERA-RELATIVE CONTROLS */
+				/*******************************/
 
 	else
 	{
 
 
-		/* ROTATE ANALOG ACCELERATION VECTOR BASED ON CAMERA POS & APPLY TO DELTA */
+				/* ROTATE ANALOG ACCELERATION VECTOR BASED ON CAMERA POS & APPLY TO DELTA */
 
 		OGLMatrix3x3_SetRotateAboutPoint(&m, &origin, gPlayerToCameraAngle);			// make a 2D rotation matrix camera-rel
 		theNode->AccelVector.x = gPlayerInfo.analogControlX;
@@ -2423,14 +2423,14 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
 		gDelta.x += theNode->AccelVector.x * CONTROL_SENSITIVITY * (1.1f - gPlayerSlipperyFactor);
 		gDelta.z += theNode->AccelVector.y * CONTROL_SENSITIVITY * (1.1f - gPlayerSlipperyFactor);
 
-		/**********************************************************/
-		/* TURN PLAYER TO AIM DIRECTION OF ACCELERATION OR MOTION */
-		/**********************************************************/
-		//
-		// Depending on how slippery the terrain is, we aim toward the direction
-		// of motion or the direction of acceleration.  We'll use the gPlayerSlipperyFactor value
-		// to average an aim vector between the two.
-		//
+				/**********************************************************/
+				/* TURN PLAYER TO AIM DIRECTION OF ACCELERATION OR MOTION */
+				/**********************************************************/
+				//
+				// Depending on how slippery the terrain is, we aim toward the direction
+				// of motion or the direction of acceleration.  We'll use the gPlayerSlipperyFactor value
+				// to average an aim vector between the two.
+				//
 
 		FastNormalizeVector2D(gDelta.x, gDelta.z, &deltaVec, true);
 		FastNormalizeVector2D(theNode->AccelVector.x, theNode->AccelVector.y, &accVec, true);
@@ -2441,10 +2441,10 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
 		TurnObjectTowardTarget(theNode, &gCoord, gCoord.x + aimVec.x, gCoord.z + aimVec.y, 8.0f, false);
 	}
 
-	/* CALC SPEED */
+				/* CALC SPEED */
 
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);					// calc 2D speed value
-	if((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
+	if ((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
 	{
 	}
 	else
@@ -2453,7 +2453,7 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
 		gDelta.x = gDelta.z = 0;
 	}
 
-	if(theNode->Speed2D > MAX_BUBBLE_SPEED)						// see if limit top speed
+	if (theNode->Speed2D > MAX_BUBBLE_SPEED)						// see if limit top speed
 	{
 		float	tweak;
 
@@ -2466,36 +2466,36 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
 	}
 
 
-	/* MOVE IT */
+			/* MOVE IT */
 
-	gCoord.x += gDelta.x * fps;
-	gCoord.y += gDelta.y * fps;
-	gCoord.z += gDelta.z * fps;
+	gCoord.x += gDelta.x*fps;
+	gCoord.y += gDelta.y*fps;
+	gCoord.z += gDelta.z*fps;
 
 
-	/******************************/
-	/* DO OBJECT COLLISION DETECT */
-	/******************************/
-	//
-	// for the bubble, we do only rudimentary collision to see
-	// if we need to pop the bubble
-	//
+			/******************************/
+			/* DO OBJECT COLLISION DETECT */
+			/******************************/
+			//
+			// for the bubble, we do only rudimentary collision to see
+			// if we need to pop the bubble
+			//
 
-	if(DoSimpleBoxCollision(gCoord.y + gSoapBubble->TopOff, gCoord.y + gSoapBubble->BottomOff,
-		gCoord.x + gSoapBubble->LeftOff, gCoord.x + gSoapBubble->RightOff,
-		gCoord.z + gSoapBubble->FrontOff, gCoord.z + gSoapBubble->BackOff,
-		CTYPE_MISC | CTYPE_ENEMY | CTYPE_TRIGGER))
+	if (DoSimpleBoxCollision(gCoord.y + gSoapBubble->TopOff, gCoord.y + gSoapBubble->BottomOff,
+							 gCoord.x + gSoapBubble->LeftOff, gCoord.x + gSoapBubble->RightOff,
+							 gCoord.z + gSoapBubble->FrontOff, gCoord.z + gSoapBubble->BackOff,
+							CTYPE_MISC|CTYPE_ENEMY|CTYPE_TRIGGER))
 	{
 		hit = true;
 	}
 
-	/*************************/
-	/* CHECK FENCE COLLISION */
-	/*************************/
+				/*************************/
+				/* CHECK FENCE COLLISION */
+				/*************************/
 
 	oldRadius = theNode->BoundingSphereRadius;								// tweak the radius for this
-	theNode->BoundingSphereRadius = gSoapBubble->BBox.max.x;
-	if(DoFenceCollision(theNode) || hit)
+	theNode->BoundingSphereRadius =  gSoapBubble->BBox.max.x;
+	if (DoFenceCollision(theNode) || hit)
 	{
 		PopSoapBubble(gSoapBubble);
 	}
@@ -2512,28 +2512,28 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
 
 static void DoRobotFrictionAndGravity(ObjNode *theNode, float friction)
 {
-	OGLVector2D	v;
-	float	x, z, fps;
+OGLVector2D	v;
+float	x,z,fps;
 
 	fps = gFramesPerSecondFrac;
 
-	/**************/
-	/* DO GRAVITY */
-	/**************/
+			/**************/
+			/* DO GRAVITY */
+			/**************/
 
-	gDelta.y -= gGravity * fps;					// add gravity
+	gDelta.y -= gGravity*fps;					// add gravity
 
-	if(gDelta.y < 0.0f)							// if falling, keep dy at least -1.0 to avoid collision jitter on platforms
-		if(gDelta.y > (-20.0f * fps))
+	if (gDelta.y < 0.0f)							// if falling, keep dy at least -1.0 to avoid collision jitter on platforms
+		if (gDelta.y > (-20.0f * fps))
 			gDelta.y = (-20.0f * fps);
 
 
-	/***************/
-	/* DO FRICTION */
-	/***************/
-	//
-	// Dont do friction if player is pressing controls
-	//
+			/***************/
+			/* DO FRICTION */
+			/***************/
+			//
+			// Dont do friction if player is pressing controls
+			//
 
 	if(true) // Always player relative controls in VR
 	{
@@ -2546,15 +2546,15 @@ static void DoRobotFrictionAndGravity(ObjNode *theNode, float friction)
 	{
 		switch(theNode->Skeleton->AnimNum)
 		{
-		case	PLAYER_ANIM_STAND:
-		case	PLAYER_ANIM_WALK:
-		case	PLAYER_ANIM_WALKWITHGUN:
-		case	PLAYER_ANIM_STANDWITHGUN:
-		case	PLAYER_ANIM_PUNCH:
-		case	PLAYER_ANIM_PICKUPDEPOSIT:
-		case	PLAYER_ANIM_PICKUPANDHOLDGUN:
-			friction *= 2.0f;
-			break;
+			case	PLAYER_ANIM_STAND:
+			case	PLAYER_ANIM_WALK:
+			case	PLAYER_ANIM_WALKWITHGUN:
+			case	PLAYER_ANIM_STANDWITHGUN:
+			case	PLAYER_ANIM_PUNCH:
+			case	PLAYER_ANIM_PICKUPDEPOSIT:
+			case	PLAYER_ANIM_PICKUPANDHOLDGUN:
+					friction *= 2.0f;
+					break;
 		}
 	}
 
@@ -2569,35 +2569,35 @@ static void DoRobotFrictionAndGravity(ObjNode *theNode, float friction)
 	x = -v.x * friction;						// make counter-motion vector
 	z = -v.y * friction;
 
-	if(gDelta.x < 0.0f)						// decelerate against vector
+	if (gDelta.x < 0.0f)						// decelerate against vector
 	{
 		gDelta.x += x;
-		if(gDelta.x > 0.0f)					// see if sign changed
+		if (gDelta.x > 0.0f)					// see if sign changed
 			gDelta.x = 0;
 	}
 	else
-		if(gDelta.x > 0.0f)
-		{
-			gDelta.x += x;
-			if(gDelta.x < 0.0f)
-				gDelta.x = 0;
-		}
+	if (gDelta.x > 0.0f)
+	{
+		gDelta.x += x;
+		if (gDelta.x < 0.0f)
+			gDelta.x = 0;
+	}
 
-	if(gDelta.z < 0.0f)
+	if (gDelta.z < 0.0f)
 	{
 		gDelta.z += z;
-		if(gDelta.z > 0.0f)
+		if (gDelta.z > 0.0f)
 			gDelta.z = 0;
 	}
 	else
-		if(gDelta.z > 0.0f)
-		{
-			gDelta.z += z;
-			if(gDelta.z < 0.0f)
-				gDelta.z = 0;
-		}
+	if (gDelta.z > 0.0f)
+	{
+		gDelta.z += z;
+		if (gDelta.z < 0.0f)
+			gDelta.z = 0;
+	}
 
-	if((gDelta.x == 0.0f) && (gDelta.z == 0.0f))
+	if ((gDelta.x == 0.0f) && (gDelta.z == 0.0f))
 	{
 		theNode->Speed2D = 0;
 	}
@@ -2616,15 +2616,15 @@ static void DoRobotFrictionAndGravity(ObjNode *theNode, float friction)
 
 static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrain)
 {
-	short		i;
-	ObjNode *hitObj;
-	unsigned long	ctype;
-	u_char		sides;
-	float		distToFloor, terrainY, fps = gFramesPerSecondFrac;
-	float		bottomOff;
-	Boolean		killed = false;
+short		i;
+ObjNode		*hitObj;
+unsigned long	ctype;
+u_char		sides;
+float		distToFloor, terrainY, fps = gFramesPerSecondFrac;
+float		bottomOff;
+Boolean		killed = false;
 
-	/* DETERMINE CTYPE BITS TO CHECK FOR */
+			/* DETERMINE CTYPE BITS TO CHECK FOR */
 
 	ctype = PLAYER_COLLISION_CTYPE;
 
@@ -2639,26 +2639,26 @@ static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrai
 			// this also sets the ONGROUND status bit if on a solid object.
 			//
 
-	if(useBBoxForTerrain)
+	if (useBBoxForTerrain)
 		theNode->BottomOff = theNode->BBox.min.y;
 	else
 		theNode->BottomOff = gPlayerBottomOff;
 
 	sides = HandleCollisions(theNode, ctype, -.3);
 
-	/* SCAN FOR INTERESTING STUFF */
+			/* SCAN FOR INTERESTING STUFF */
 
 
-	for(i = 0; i < gNumCollisions; i++)
+	for (i=0; i < gNumCollisions; i++)
 	{
-		if(gCollisionList[i].type == COLLISION_TYPE_OBJ)
+		if (gCollisionList[i].type == COLLISION_TYPE_OBJ)
 		{
 			hitObj = gCollisionList[i].objectPtr;				// get ObjNode of this collision
 
-			if(hitObj->CType == INVALID_NODE_FLAG)				// see if has since become invalid
+			if (hitObj->CType == INVALID_NODE_FLAG)				// see if has since become invalid
 				continue;
 
-			if(gCollisionList[i].sides & SIDE_BITS_BOTTOM)		// if bottom hit then set gPlayerSlipperyFactor from the object's friction value
+			if (gCollisionList[i].sides & SIDE_BITS_BOTTOM)		// if bottom hit then set gPlayerSlipperyFactor from the object's friction value
 				gPlayerSlipperyFactor = hitObj->Friction;
 
 
@@ -2667,9 +2667,9 @@ static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrai
 
 			/* CHECK FOR TOTALLY IMPENETRABLE */
 
-			if(ctype & CTYPE_IMPENETRABLE2)
+			if (ctype & CTYPE_IMPENETRABLE2)
 			{
-				if(!(gCollisionList[i].sides & SIDE_BITS_BOTTOM))	// dont do this if we landed on top of it
+				if (!(gCollisionList[i].sides & SIDE_BITS_BOTTOM))	// dont do this if we landed on top of it
 				{
 					gCoord.x = theNode->OldCoord.x;					// dont take any chances, just move back to original safe place
 					gCoord.z = theNode->OldCoord.z;
@@ -2678,30 +2678,30 @@ static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrai
 
 			/* CHECK FOR HURT ME */
 
-			if(ctype & CTYPE_HURTME)
+			if (ctype & CTYPE_HURTME)
 			{
 				PlayerGotHit(hitObj, 0);
 
-				if(ctype & CTYPE_FLAMING)							// see if hurter was flaming
+				if (ctype & CTYPE_FLAMING)							// see if hurter was flaming
 					gPlayerInfo.burnTimer = 2.5;
 			}
 		}
 	}
 
-	/*************************************/
-	/* CHECK & HANDLE TERRAIN  COLLISION */
-	/*************************************/
+		/*************************************/
+		/* CHECK & HANDLE TERRAIN  COLLISION */
+		/*************************************/
 
-	if(useBBoxForTerrain)
+	if (useBBoxForTerrain)
 		bottomOff = theNode->BBox.min.y;							// use bbox for bottom
 	else
 		bottomOff = theNode->BottomOff;								// use collision box for bottom
 
-	terrainY = GetTerrainY(gCoord.x, gCoord.z);					// get terrain Y
+	terrainY =  GetTerrainY(gCoord.x, gCoord.z);					// get terrain Y
 
 	distToFloor = (gCoord.y + bottomOff) - terrainY;				// calc amount I'm above or under
 
-	if(distToFloor <= 0.0f)										// see if on or under floor
+	if (distToFloor <= 0.0f)										// see if on or under floor
 	{
 		gCoord.y = terrainY - bottomOff;
 		gDelta.y = -200.0f;											// keep some downward momentum
@@ -2710,65 +2710,65 @@ static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrai
 
 		switch(gLevelNum)
 		{
-		case	LEVEL_NUM_BLOBBOSS:								// if touch blob boss ground, then hurt player and bounce back up
-			PlayerLoseHealth(.25, PLAYER_DEATH_TYPE_EXPLODE);
-			gDelta.y = 2500.0f;
-			PlayEffect3D(EFFECT_SLIMEBOUNCE, &gCoord);
-			break;
+			case	LEVEL_NUM_BLOBBOSS:								// if touch blob boss ground, then hurt player and bounce back up
+					PlayerLoseHealth(.25, PLAYER_DEATH_TYPE_EXPLODE);
+					gDelta.y = 2500.0f;
+					PlayEffect3D(EFFECT_SLIMEBOUNCE, &gCoord);
+					break;
 
-		case	LEVEL_NUM_CLOUD:								// see if touch electric floor
-			if(gTileAttribFlags & (TILE_ATTRIB_ELECTROCUTE_AREA0 | TILE_ATTRIB_ELECTROCUTE_AREA1))
-			{
-				if(gTileAttribFlags & TILE_ATTRIB_ELECTROCUTE_AREA0)	// check area #0
-				{
-					if(!gBumperCarGateBlown[0])
-						PlayerTouchedElectricFloor(theNode);
-				}
-				else													// check area #1
-				{
-					if(!gBumperCarGateBlown[1])
-						PlayerTouchedElectricFloor(theNode);
-				}
-			}
-			break;
+			case	LEVEL_NUM_CLOUD:								// see if touch electric floor
+					if (gTileAttribFlags & (TILE_ATTRIB_ELECTROCUTE_AREA0|TILE_ATTRIB_ELECTROCUTE_AREA1))
+					{
+						if (gTileAttribFlags & TILE_ATTRIB_ELECTROCUTE_AREA0)	// check area #0
+						{
+							if (!gBumperCarGateBlown[0])
+								PlayerTouchedElectricFloor(theNode);
+						}
+						else													// check area #1
+						{
+							if (!gBumperCarGateBlown[1])
+								PlayerTouchedElectricFloor(theNode);
+						}
+					}
+					break;
 		}
 	}
 
 
-	/* DEAL WITH SLOPES */
-	//
-	// Using the floor normal here, apply some deltas to it.
-	// Only apply slopes when on the ground (or really close to it)
-	//
+			/* DEAL WITH SLOPES */
+			//
+			// Using the floor normal here, apply some deltas to it.
+			// Only apply slopes when on the ground (or really close to it)
+			//
 
-	if((fabs(gPlayerInfo.analogControlX) < 0.5f) && (fabs(gPlayerInfo.analogControlZ) < 0.5f))			// only do slopes if player isn't controlling
+	if ((fabs(gPlayerInfo.analogControlX) < 0.5f) && (fabs(gPlayerInfo.analogControlZ) < 0.5f))			// only do slopes if player isn't controlling
 	{
-		if((distToFloor <= 0.0f) || (gPlayerInfo.distToFloor < 15.0f))
+		if ((distToFloor <= 0.0f) || (gPlayerInfo.distToFloor < 15.0f))
 		{
 			gDelta.x += gRecentTerrainNormal.x * (fps * PLAYER_SLOPE_ACCEL);
 			gDelta.z += gRecentTerrainNormal.z * (fps * PLAYER_SLOPE_ACCEL);
 		}
 	}
 
-	/**************************/
-	/* SEE IF IN WATER VOLUME */
-	/**************************/
+			/**************************/
+			/* SEE IF IN WATER VOLUME */
+			/**************************/
 
-	if(!killed)
+	if (!killed)
 	{
 		int		patchNum;
 		Boolean	wasInWater;
 
-		/* REMEMBER IF ALREADY IN WATER */
+					/* REMEMBER IF ALREADY IN WATER */
 
-		if(theNode->StatusBits & STATUS_BIT_UNDERWATER)
+		if (theNode->StatusBits & STATUS_BIT_UNDERWATER)
 			wasInWater = true;
 		else
 			wasInWater = false;
 
-		/* CHECK IF IN WATER NOW */
+					/* CHECK IF IN WATER NOW */
 
-		if(DoWaterCollisionDetect(theNode, gCoord.x, gCoord.y + theNode->BottomOff + 50.0f, gCoord.z, &patchNum))
+		if (DoWaterCollisionDetect(theNode, gCoord.x, gCoord.y+theNode->BottomOff + 50.0f, gCoord.z, &patchNum))
 		{
 			gPlayerInfo.waterPatch = patchNum;
 
@@ -2776,24 +2776,24 @@ static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrai
 
 			switch(gWaterList[patchNum].type)
 			{
-				/* JUNGLE MUD */
+					/* JUNGLE MUD */
 
-			case	WATER_TYPE_MUD:
-				ApplyFrictionToDeltas(300.0f, &gDelta);									// mud is viscous so slow player
-				killed = PlayerLoseHealth(.3f * fps, PLAYER_DEATH_TYPE_DROWN);			// lose health
-				MakeSteam(theNode, gCoord.x, gCoord.y, gCoord.z);
-				break;
+				case	WATER_TYPE_MUD:
+						ApplyFrictionToDeltas(300.0f, &gDelta);									// mud is viscous so slow player
+						killed = PlayerLoseHealth(.3f * fps, PLAYER_DEATH_TYPE_DROWN);			// lose health
+						MakeSteam(theNode, gCoord.x, gCoord.y, gCoord.z);
+						break;
 
-			case	WATER_TYPE_LAVA:
-				ApplyFrictionToDeltas(2000.0f, &gDelta);								// lava is viscous so slow player
-				killed = PlayerLoseHealth(.5f * fps, PLAYER_DEATH_TYPE_EXPLODE);		// lose health
-				BurnFire(theNode, gCoord.x, gCoord.y, gCoord.z, true, PARTICLE_SObjType_Fire, 4.0, PARTICLE_FLAGS_ALLAIM);
-				break;
+				case	WATER_TYPE_LAVA:
+						ApplyFrictionToDeltas(2000.0f, &gDelta);								// lava is viscous so slow player
+						killed = PlayerLoseHealth(.5f * fps, PLAYER_DEATH_TYPE_EXPLODE);		// lose health
+						BurnFire(theNode, gCoord.x, gCoord.y, gCoord.z, true, PARTICLE_SObjType_Fire, 4.0, PARTICLE_FLAGS_ALLAIM);
+						break;
 
-				/* GOOD OLD ZAPPING H2O */
-			default:
-				if(!wasInWater)
-					PlayerEntersWater(theNode, patchNum);
+						/* GOOD OLD ZAPPING H2O */
+				default:
+						if (!wasInWater)
+							PlayerEntersWater(theNode, patchNum);
 			}
 		}
 	}
@@ -2810,29 +2810,29 @@ static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrai
 
 static void CheckPunchCollision(ObjNode *player)
 {
-	static OGLPoint3D fistOff = { 0,-12 ,0 };
-	OGLPoint3D	fistCoord;
-	int			i;
-	ObjNode *hitObj;
-	Boolean		endPunch;
-	float		fistSize = 30.0f * gPlayerInfo.scale;
+static OGLPoint3D fistOff = {0,-12 ,0};
+OGLPoint3D	fistCoord;
+int			i;
+ObjNode		*hitObj;
+Boolean		endPunch;
+float		fistSize = 30.0f * gPlayerInfo.scale;
 
 	FindCoordOnJoint(player, PLAYER_JOINT_RIGHTHAND, &fistOff, &fistCoord);			// calc coord of fist
 
-	if(DoSimpleBoxCollision(fistCoord.y + fistSize, fistCoord.y - fistSize,
-		fistCoord.x - fistSize, fistCoord.x + fistSize,
-		fistCoord.z + fistSize, fistCoord.z - fistSize,
-		CTYPE_MISC | CTYPE_ENEMY | CTYPE_TRIGGER | CTYPE_POWERUP))
+	if (DoSimpleBoxCollision(fistCoord.y + fistSize, fistCoord.y - fistSize,
+							 fistCoord.x - fistSize, fistCoord.x + fistSize,
+							 fistCoord.z + fistSize, fistCoord.z - fistSize,
+							 CTYPE_MISC|CTYPE_ENEMY|CTYPE_TRIGGER|CTYPE_POWERUP))
 	{
-		for(i = 0; i < gNumCollisions; i++)										// affect all hit objects
+		for (i = 0; i < gNumCollisions; i++)										// affect all hit objects
 		{
 			hitObj = gCollisionList[i].objectPtr;									// get hit ObjNode
-			if(hitObj)
+			if (hitObj)
 			{
-				if(hitObj->HitByWeaponHandler[WEAPON_TYPE_FIST])					// see if there is a handler for the punch
+				if (hitObj->HitByWeaponHandler[WEAPON_TYPE_FIST])					// see if there is a handler for the punch
 				{
 					endPunch = (hitObj->HitByWeaponHandler[WEAPON_TYPE_FIST])(gPlayerInfo.rightHandObj, hitObj, &fistCoord, nil);	// call the handler
-					if(endPunch)
+					if (endPunch)
 					{
 						player->PunchCanHurt = false;
 						PlayEffect3D(EFFECT_PUNCHHIT, &fistCoord);
@@ -2856,16 +2856,16 @@ static void CheckPunchCollision(ObjNode *player)
 
 static void CheckPlayerActionControls(ObjNode *theNode)
 {
-	/* SEE IF DO CHEAT */
+		/* SEE IF DO CHEAT */
 
-	if(GetKeyState(SDL_SCANCODE_B) &&
+	if (GetKeyState(SDL_SCANCODE_B) &&
 		GetKeyState(SDL_SCANCODE_R) &&
 		GetKeyState(SDL_SCANCODE_I))
 	{
-		if(gPlayerInfo.lives < 3)
-			gPlayerInfo.lives = 3;
-		gPlayerInfo.health = 1.0;
-		gPlayerInfo.fuel = 1.0;
+		if (gPlayerInfo.lives < 3)
+			gPlayerInfo.lives 	= 3;
+		gPlayerInfo.health 	= 1.0;
+		gPlayerInfo.fuel 	= 1.0;
 		gPlayerInfo.jumpJet = 1.0;
 		gPlayerInfo.weaponInventory[6].type = WEAPON_TYPE_SUPERNOVA;
 		gPlayerInfo.weaponInventory[6].quantity = 99;
@@ -2873,72 +2873,72 @@ static void CheckPlayerActionControls(ObjNode *theNode)
 		gPlayerInfo.weaponInventory[7].quantity = 99;
 	}
 
-	/***************/
-	/* SEE IF JUMP */
-	/***************/
+			/***************/
+			/* SEE IF JUMP */
+			/***************/
 
-	if(GetNewNeedState(kNeed_Jump))										// see if user pressed the key
+	if (GetNewNeedState(kNeed_Jump))										// see if user pressed the key
 	{
 		/* SEE IF ENTER CANNON ON CLOUD LEVEL */
 
-		if(gLevelNum == LEVEL_NUM_CLOUD)
+		if (gLevelNum == LEVEL_NUM_CLOUD)
 		{
 			float	cannonTipX, cannonTipZ;
 			gCannon = IsPlayerInPositionToEnterCannon(&cannonTipX, &cannonTipZ);		// see if in position for cannon
 
-			if(gCannon != nil)
+			if (gCannon != nil)
 			{
 				gCoord.x = cannonTipX;
 				gCoord.z = cannonTipZ;
 				theNode->Rot.y = gCannon->Rot.y + PI;
 				MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_CLIMBINTO, 7.0);
 				StartCannonFuse(gCannon);
-				gCameraUserRotY = -PI / 2;									// swing camera to side
+				gCameraUserRotY = -PI/2;									// swing camera to side
 				DisableHelpType(HELP_MESSAGE_INTOCANNON);
 				goto no_jump;
 			}
 		}
 
-		/* CHECK JUMP-JET */
+			/* CHECK JUMP-JET */
 
-		if((theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP) ||
+		if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP) ||
 			(theNode->Skeleton->AnimNum == PLAYER_ANIM_FALL))			// if already jumping or falling then try Jump Jet
 		{
-			if(fabs(gDelta.y) < 800.0f)								// do it now if near apex of jump
+			if (fabs(gDelta.y) < 800.0f)								// do it now if near apex of jump
 				StartJumpJet(theNode);
 			else
-				if(theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)			// not @ apex, but if already jumping then tag to do JJ @ apex
-					gDoJumpJetAtApex = true;
-				else
-					if(gPlayerInfo.distToFloor > 200.0f)						// not @ apex, but if falling still allow JJ if high enough off ground
-						StartJumpJet(theNode);
+			if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)			// not @ apex, but if already jumping then tag to do JJ @ apex
+				gDoJumpJetAtApex = true;
+			else
+			if (gPlayerInfo.distToFloor > 200.0f)						// not @ apex, but if falling still allow JJ if high enough off ground
+				StartJumpJet(theNode);
 		}
 
-		/* CHECK REGULAR JUMP */
+			/* CHECK REGULAR JUMP */
 
 		else
-			if((theNode->StatusBits & STATUS_BIT_ONGROUND) || (gPlayerInfo.distToFloor < 15.0f))		// must be on something solid
+		if ((theNode->StatusBits & STATUS_BIT_ONGROUND)	|| (gPlayerInfo.distToFloor < 15.0f))		// must be on something solid
+		{
+			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_JUMP, 5.0f);
+			PlayEffect3D(EFFECT_JUMP, &gCoord);
+
+			gDoJumpJetAtApex = false;
+
+			gDelta.y += JUMP_DELTA;
+
+			if (theNode->MPlatform != nil)			// if jumping off of mplatform then also use platform's deltas
 			{
-				MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_JUMP, 5.0f);
-				PlayEffect3D(EFFECT_JUMP, &gCoord);
-
-				gDoJumpJetAtApex = false;
-
-				gDelta.y += JUMP_DELTA;
-
-				if(theNode->MPlatform != nil)			// if jumping off of mplatform then also use platform's deltas
-				{
-					gDelta.x += theNode->MPlatform->Delta.x;
-					gDelta.y += theNode->MPlatform->Delta.y;
-					gDelta.z += theNode->MPlatform->Delta.z;
-				}
+				gDelta.x += theNode->MPlatform->Delta.x;
+				gDelta.y += theNode->MPlatform->Delta.y;
+				gDelta.z += theNode->MPlatform->Delta.z;
 			}
+		}
 	}
 no_jump:
 
-	/******************/
-	/* HANDLE WEAPONS */
-	/******************/
+		/******************/
+		/* HANDLE WEAPONS */
+		/******************/
 
 	CheckPOWControls(theNode);
 }
@@ -2948,10 +2948,10 @@ no_jump:
 
 static void StartJumpJet(ObjNode *theNode)
 {
-	if(!gResetJumpJet)								// cannot do this until jump jet has been reset
+	if (!gResetJumpJet)								// cannot do this until jump jet has been reset
 		return;
 
-	if(gPlayerInfo.jumpJet <= 0.0f)				// can't do it if out of jump jet fuel
+	if (gPlayerInfo.jumpJet <= 0.0f)				// can't do it if out of jump jet fuel
 	{
 		gDoJumpJetAtApex = false;
 		PlayEffect(EFFECT_NOJUMPJET);
@@ -2960,14 +2960,14 @@ static void StartJumpJet(ObjNode *theNode)
 	}
 
 	gPlayerInfo.jumpJet -= .1f;						// dec fuel
-	if(gPlayerInfo.jumpJet < 0.0f)
+	if (gPlayerInfo.jumpJet < 0.0f)
 		gPlayerInfo.jumpJet = 0.0f;
 
 	gResetJumpJet = false;
 
-	/* SET ANIM */
+			/* SET ANIM */
 
-	if(gPlayerInfo.scaleRatio > 1.0f)				// do special version of player is giant
+	if (gPlayerInfo.scaleRatio > 1.0f)				// do special version of player is giant
 	{
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_GIANTJUMPJET, 6.0f);
 		theNode->Skeleton->AnimSpeed = .6;
@@ -2976,26 +2976,26 @@ static void StartJumpJet(ObjNode *theNode)
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_JUMPJET, 6.0f);
 
 
-	/* SET SOME VARIABLES */
+			/* SET SOME VARIABLES */
 
 	gDelta.y = 0;
 	gPlayerInfo.jumpJetSpeed = 0;
 	theNode->JumpJetEnginesOff = false;
 
 
-	/* START PARTICLES */
+			/* START PARTICLES */
 
 	gPlayerInfo.jjParticleGroup[0] = -1;			// white sparks
-	gPlayerInfo.jjParticleMagic[0] = 0;
-	gPlayerInfo.jjParticleTimer[0] = 0;
+	gPlayerInfo.jjParticleMagic[0]	= 0;
+	gPlayerInfo.jjParticleTimer[0]	= 0;
 
 	gPlayerInfo.jjParticleGroup[1] = -1;			// smoke
-	gPlayerInfo.jjParticleMagic[1] = 0;
-	gPlayerInfo.jjParticleTimer[1] = 0;
+	gPlayerInfo.jjParticleMagic[1]	= 0;
+	gPlayerInfo.jjParticleTimer[1]	= 0;
 
 
 
-	/* CREATE SPARKLE */
+		/* CREATE SPARKLE */
 
 	CreatePlayerJumpJetSparkles(theNode);
 
@@ -3018,18 +3018,18 @@ static void EndJumpJet(ObjNode *theNode)
 
 static void UpdateJumpJetParticles(ObjNode *theNode)
 {
-	float	fps = gFramesPerSecondFrac;
-	int		particleGroup, magicNum;
-	NewParticleGroupDefType	groupDef;
-	NewParticleDefType	newParticleDef;
-	OGLVector3D			d;
-	OGLPoint3D			p;
-	int					i;
-	float				x, y, z;
-	static const OGLPoint3D		particleBaseOff = { 0,-100,0 };
-	OGLPoint3D			particleBase;
+float	fps = gFramesPerSecondFrac;
+int		particleGroup,magicNum;
+NewParticleGroupDefType	groupDef;
+NewParticleDefType	newParticleDef;
+OGLVector3D			d;
+OGLPoint3D			p;
+int					i;
+float				x,y,z;
+static const OGLPoint3D		particleBaseOff = {0,-100,0};
+OGLPoint3D			particleBase;
 
-	/* CALC FOOT POINT */
+				/* CALC FOOT POINT */
 
 	FindCoordOnJoint(theNode, PLAYER_JOINT_BASE, &particleBaseOff, &particleBase);
 	x = particleBase.x;
@@ -3037,39 +3037,39 @@ static void UpdateJumpJetParticles(ObjNode *theNode)
 	z = particleBase.z;
 
 
-	/*********************/
-	/* MAKE WHITE SPARKS */
-	/*********************/
+			/*********************/
+			/* MAKE WHITE SPARKS */
+			/*********************/
 
 	gPlayerInfo.jjParticleTimer[0] -= fps;											// see if add particles
-	if(gPlayerInfo.jjParticleTimer[0] <= 0.0f)
+	if (gPlayerInfo.jjParticleTimer[0] <= 0.0f)
 	{
 		gPlayerInfo.jjParticleTimer[0] += .03f;									// reset timer
 
-		particleGroup = gPlayerInfo.jjParticleGroup[0];
-		magicNum = gPlayerInfo.jjParticleMagic[0];
+		particleGroup 	= gPlayerInfo.jjParticleGroup[0];
+		magicNum 		= gPlayerInfo.jjParticleMagic[0];
 
-		if((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
+		if ((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
 		{
 			gPlayerInfo.jjParticleMagic[0] = magicNum = MyRandomLong();			// generate a random magic num
 
-			groupDef.magicNum = magicNum;
-			groupDef.type = PARTICLE_TYPE_FALLINGSPARKS;
-			groupDef.flags = PARTICLE_FLAGS_DONTCHECKGROUND;
-			groupDef.gravity = 800;
-			groupDef.magnetism = 0;
-			groupDef.baseScale = 20.0f * gPlayerInfo.scaleRatio;
-			groupDef.decayRate = .8;
-			groupDef.fadeRate = 1.4;
-			groupDef.particleTextureNum = PARTICLE_SObjType_WhiteSpark2;
-			groupDef.srcBlend = GL_SRC_ALPHA;
-			groupDef.dstBlend = GL_ONE;
+			groupDef.magicNum				= magicNum;
+			groupDef.type					= PARTICLE_TYPE_FALLINGSPARKS;
+			groupDef.flags					= PARTICLE_FLAGS_DONTCHECKGROUND;
+			groupDef.gravity				= 800;
+			groupDef.magnetism				= 0;
+			groupDef.baseScale				= 20.0f * gPlayerInfo.scaleRatio;
+			groupDef.decayRate				= .8;
+			groupDef.fadeRate				= 1.4;
+			groupDef.particleTextureNum		= PARTICLE_SObjType_WhiteSpark2;
+			groupDef.srcBlend				= GL_SRC_ALPHA;
+			groupDef.dstBlend				= GL_ONE;
 			gPlayerInfo.jjParticleGroup[0] = particleGroup = NewParticleGroup(&groupDef);
 		}
 
-		if(particleGroup != -1)
+		if (particleGroup != -1)
 		{
-			for(i = 0; i < 7; i++)
+			for (i = 0; i < 7; i++)
 			{
 				p.x = x + RandomFloat2() * 30.0f;
 				p.y = y + RandomFloat2() * 30.0f;
@@ -3079,14 +3079,14 @@ static void UpdateJumpJetParticles(ObjNode *theNode)
 				d.y = RandomFloat2() * 140.0f;
 				d.z = RandomFloat2() * 140.0f;
 
-				newParticleDef.groupNum = particleGroup;
-				newParticleDef.where = &p;
-				newParticleDef.delta = &d;
-				newParticleDef.scale = 1.0f;
-				newParticleDef.rotZ = 0;
-				newParticleDef.rotDZ = 0;
-				newParticleDef.alpha = 1.0;
-				if(AddParticleToGroup(&newParticleDef))
+				newParticleDef.groupNum		= particleGroup;
+				newParticleDef.where		= &p;
+				newParticleDef.delta		= &d;
+				newParticleDef.scale		= 1.0f;
+				newParticleDef.rotZ			= 0;
+				newParticleDef.rotDZ		= 0;
+				newParticleDef.alpha		= 1.0;
+				if (AddParticleToGroup(&newParticleDef))
 				{
 					gPlayerInfo.jjParticleGroup[0] = -1;
 					break;
@@ -3096,39 +3096,39 @@ static void UpdateJumpJetParticles(ObjNode *theNode)
 	}
 
 
-	/**************/
-	/* MAKE SMOKE */
-	/**************/
+			/**************/
+			/* MAKE SMOKE */
+			/**************/
 
 	gPlayerInfo.jjParticleTimer[1] -= fps;											// see if add particles
-	if(gPlayerInfo.jjParticleTimer[1] <= 0.0f)
+	if (gPlayerInfo.jjParticleTimer[1] <= 0.0f)
 	{
 		gPlayerInfo.jjParticleTimer[1] += .05f;									// reset timer
 
-		particleGroup = gPlayerInfo.jjParticleGroup[1];
-		magicNum = gPlayerInfo.jjParticleMagic[1];
+		particleGroup 	= gPlayerInfo.jjParticleGroup[1];
+		magicNum 		= gPlayerInfo.jjParticleMagic[1];
 
-		if((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
+		if ((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
 		{
 			gPlayerInfo.jjParticleMagic[1] = magicNum = MyRandomLong();			// generate a random magic num
 
-			groupDef.magicNum = magicNum;
-			groupDef.type = PARTICLE_TYPE_FALLINGSPARKS;
-			groupDef.flags = PARTICLE_FLAGS_DONTCHECKGROUND;
-			groupDef.gravity = 0;
-			groupDef.magnetism = 0;
-			groupDef.baseScale = 20.0f * gPlayerInfo.scaleRatio;
-			groupDef.decayRate = -.2;
-			groupDef.fadeRate = .7;
-			groupDef.particleTextureNum = PARTICLE_SObjType_GreySmoke;
-			groupDef.srcBlend = GL_SRC_ALPHA;
-			groupDef.dstBlend = GL_ONE_MINUS_SRC_ALPHA;
+			groupDef.magicNum				= magicNum;
+			groupDef.type					= PARTICLE_TYPE_FALLINGSPARKS;
+			groupDef.flags					= PARTICLE_FLAGS_DONTCHECKGROUND;
+			groupDef.gravity				= 0;
+			groupDef.magnetism				= 0;
+			groupDef.baseScale				= 20.0f * gPlayerInfo.scaleRatio;
+			groupDef.decayRate				= -.2;
+			groupDef.fadeRate				= .7;
+			groupDef.particleTextureNum		= PARTICLE_SObjType_GreySmoke;
+			groupDef.srcBlend				= GL_SRC_ALPHA;
+			groupDef.dstBlend				= GL_ONE_MINUS_SRC_ALPHA;
 			gPlayerInfo.jjParticleGroup[1] = particleGroup = NewParticleGroup(&groupDef);
 		}
 
-		if(particleGroup != -1)
+		if (particleGroup != -1)
 		{
-			for(i = 0; i < 8; i++)
+			for (i = 0; i < 8; i++)
 			{
 				p.x = x + RandomFloat2() * 40.0f;
 				p.y = y + RandomFloat2() * 40.0f;
@@ -3138,14 +3138,14 @@ static void UpdateJumpJetParticles(ObjNode *theNode)
 				d.y = RandomFloat2() * 40.0f;
 				d.z = RandomFloat2() * 40.0f;
 
-				newParticleDef.groupNum = particleGroup;
-				newParticleDef.where = &p;
-				newParticleDef.delta = &d;
-				newParticleDef.scale = RandomFloat() + 1.0f;
-				newParticleDef.rotZ = RandomFloat() * PI2;
-				newParticleDef.rotDZ = RandomFloat2();
-				newParticleDef.alpha = .4f + RandomFloat() * .3f;
-				if(AddParticleToGroup(&newParticleDef))
+				newParticleDef.groupNum		= particleGroup;
+				newParticleDef.where		= &p;
+				newParticleDef.delta		= &d;
+				newParticleDef.scale		= RandomFloat() + 1.0f;
+				newParticleDef.rotZ			= RandomFloat() * PI2;
+				newParticleDef.rotDZ		= RandomFloat2();
+				newParticleDef.alpha		= .4f + RandomFloat() * .3f;
+				if (AddParticleToGroup(&newParticleDef))
 				{
 					gPlayerInfo.jjParticleGroup[1] = -1;
 					break;
@@ -3163,7 +3163,7 @@ static void UpdateJumpJetParticles(ObjNode *theNode)
 
 void SetPlayerWalkAnim(ObjNode *theNode)
 {
-	if(gPlayerInfo.holdingGun)
+	if (gPlayerInfo.holdingGun)
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALKWITHGUN, 9);
 	else
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALK, 9);
@@ -3174,7 +3174,7 @@ void SetPlayerWalkAnim(ObjNode *theNode)
 
 static Boolean IsPlayerDoingWalkAnim(ObjNode *theNode)
 {
-	if((theNode->Skeleton->AnimNum == PLAYER_ANIM_WALK) ||
+	if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_WALK) ||
 		(theNode->Skeleton->AnimNum == PLAYER_ANIM_WALKWITHGUN))
 	{
 		return(true);
@@ -3188,7 +3188,7 @@ static Boolean IsPlayerDoingWalkAnim(ObjNode *theNode)
 
 void SetPlayerStandAnim(ObjNode *theNode, float speed)
 {
-	if(gPlayerInfo.holdingGun)
+	if (gPlayerInfo.holdingGun)
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STANDWITHGUN, speed);
 	else
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STAND, speed);
@@ -3199,7 +3199,7 @@ void SetPlayerStandAnim(ObjNode *theNode, float speed)
 
 static Boolean IsPlayerDoingStandAnim(ObjNode *theNode)
 {
-	if((theNode->Skeleton->AnimNum == PLAYER_ANIM_STAND) ||
+	if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_STAND) ||
 		(theNode->Skeleton->AnimNum == PLAYER_ANIM_STANDWITHGUN))
 	{
 		return(true);
@@ -3228,15 +3228,15 @@ void StartWeaponChangeAnim(void)
 
 static void DoPlayerMagnetSkiing(ObjNode *player)
 {
-	short		magnetMonsterID;
-	ObjNode *magMonster;
-	float		distToTarget, mx, mz, tx, tz, y;
-	OGLVector2D	v;
-	float		fps = gFramesPerSecondFrac;
-	OGLMatrix3x3	m;
+short		magnetMonsterID;
+ObjNode		*magMonster;
+float		distToTarget,mx,mz,tx,tz,y;
+OGLVector2D	v;
+float		fps = gFramesPerSecondFrac;
+OGLMatrix3x3	m;
 
 
-	/* GET INFO ABOUT THE MAGNET MONSTER */
+			/* GET INFO ABOUT THE MAGNET MONSTER */
 
 	magnetMonsterID = gTargetPickup->MagnetMonsterID;		// get ID# of the magnet so we know which monster to go to
 	magMonster = gMagnetMonsterList[magnetMonsterID];		// get objNode of magnet monster
@@ -3246,44 +3246,44 @@ static void DoPlayerMagnetSkiing(ObjNode *player)
 	mx = magMonster->Coord.x;
 	mz = magMonster->Coord.z;
 
-	/* KEEP PLAYER AIMED AT IT */
+			/* KEEP PLAYER AIMED AT IT */
 
 	TurnObjectTowardTarget(player, &gCoord, mx, mz, 11.0, false);
 
 
 
 
-	/*******************/
-	/* CALC AIM VECTOR */
-	/*******************/
+			/*******************/
+			/* CALC AIM VECTOR */
+			/*******************/
 
-/* CALC VEC FROM MONSTER TO PLAYER */
+		/* CALC VEC FROM MONSTER TO PLAYER */
 
 	v.x = gCoord.x - mx;									// calc vector from monster to player
 	v.y = gCoord.z - mz;
 	FastNormalizeVector2D(v.x, v.y, &v, true);
 
 
-	/* ROTATE BASED ON PLAYER INPUT */
+			/* ROTATE BASED ON PLAYER INPUT */
 
 	OGLMatrix3x3_SetRotate(&m, gPlayerInfo.analogControlX * .5f);
 	OGLVector2D_Transform(&v, &m, &v);
 
 
 
-	/* CALC ACCELERATION */
+			/* CALC ACCELERATION */
 
 	tx = mx + v.x * TARGET_SKIING_DIST;						// calc target point where we'd like to be
 	tz = mz + v.y * TARGET_SKIING_DIST;
 
-	distToTarget = CalcDistance(gCoord.x, gCoord.z, tx, tz);							// calc dist to target point
-	if(distToTarget > 2000.0f)								// limit it
+	distToTarget = CalcDistance(gCoord.x, gCoord.z,  tx, tz);							// calc dist to target point
+	if (distToTarget > 2000.0f)								// limit it
 		distToTarget = 2000.0f;
 
 
-	/***********/
-	/* MOVE IT */
-	/***********/
+			/***********/
+			/* MOVE IT */
+			/***********/
 
 	gDelta.x = distToTarget * -v.x * 1.5f;
 	gDelta.z = distToTarget * -v.y * 1.5f;
@@ -3294,24 +3294,24 @@ static void DoPlayerMagnetSkiing(ObjNode *player)
 	gCoord.z += gDelta.z * fps;
 
 
-	/***********************/
-	/* SEE IF HIT ANYTHING */
-	/***********************/
+			/***********************/
+			/* SEE IF HIT ANYTHING */
+			/***********************/
 
-	/* SEE IF HIT WATER */
+			/* SEE IF HIT WATER */
 
-	if(GetWaterY(gCoord.x, gCoord.z, &y))					// get water y
+	if (GetWaterY(gCoord.x, gCoord.z, &y))					// get water y
 	{
 		float	playerBottomY = gCoord.y + player->BBox.min.y + 10.0f;
 		float	diff;
 
 		diff = y - playerBottomY;
 
-		if(diff >= 0.0f)								// see if hit water
+		if (diff >= 0.0f)								// see if hit water
 		{
 			gDelta.y += 7000.0f * fps;					// thrust up
 
-			if(diff > 30.0f)							// see if too far under
+			if (diff > 30.0f)							// see if too far under
 				gCoord.y += diff - 30.0f;				// adjust back up
 
 			gCoord.y += gDelta.y * fps;
@@ -3320,35 +3320,35 @@ static void DoPlayerMagnetSkiing(ObjNode *player)
 		}
 	}
 
-	/* SEE IF HIT GROUND */
+			/* SEE IF HIT GROUND */
 
 	y = GetTerrainY(gCoord.x, gCoord.z);					// get terrain y
-	if((gCoord.y + player->BBox.min.y) <= y)				// see if hit ground
+	if ((gCoord.y + player->BBox.min.y) <= y)				// see if hit ground
 	{
 		gCoord.y = y - player->BBox.min.y;
 
-		if(gDelta.y < 0.0f)
+		if (gDelta.y < 0.0f)
 			gDelta.y *= -.5f;
 	}
 
 
-	/* SEE IF HIT SOLID OBJECT HARD */
+			/* SEE IF HIT SOLID OBJECT HARD */
 
-	if(HandleCollisions(player, CTYPE_MISC, -.6) || DoFenceCollision(player))
+	if (HandleCollisions(player, CTYPE_MISC, -.6) || DoFenceCollision(player))
 	{
-		if(player->Speed2D > 500.0f)											// see if hit hard
+		if (player->Speed2D > 500.0f)											// see if hit hard
 		{
 			EndMagnetSkiing(player, true);										// end skiing
 		}
 	}
 
-	/***********************/
-	/* SEE IF ABORT SKIING */
-	/***********************/
+			/***********************/
+			/* SEE IF ABORT SKIING */
+			/***********************/
 
-	if(gTargetPickup != nil)															// see if already aborted via collision
+	if (gTargetPickup != nil)															// see if already aborted via collision
 	{
-		if(GetNewNeedState(kNeed_Jump)
+		if (GetNewNeedState(kNeed_Jump)
 			|| GetNewNeedState(kNeed_Shoot)
 			|| GetNewNeedState(kNeed_PunchPickup))
 		{
@@ -3365,13 +3365,13 @@ static void DoPlayerMagnetSkiing(ObjNode *player)
 
 static void EndMagnetSkiing(ObjNode *player, Boolean crash)
 {
-	short		magnetMonsterID;
-	ObjNode *magMonster;
+short		magnetMonsterID;
+ObjNode		*magMonster;
 
-	if(gTargetPickup == nil)					// this can get called twice, so check if pickup==nil
+	if (gTargetPickup == nil)					// this can get called twice, so check if pickup==nil
 		return;
 
-	/* GET INFO ABOUT THE MAGNET MONSTER */
+			/* GET INFO ABOUT THE MAGNET MONSTER */
 
 	magnetMonsterID = gTargetPickup->MagnetMonsterID;		// get ID# of the magnet so we know which monster to go to
 	magMonster = gMagnetMonsterList[magnetMonsterID];		// get objNode of magnet monster
@@ -3383,7 +3383,7 @@ static void EndMagnetSkiing(ObjNode *player, Boolean crash)
 	gTargetPickup->Delta.y = 300.0f;
 	gTargetPickup->Delta.z = gDelta.z * .8f;
 
-	if(crash)
+	if (crash)
 	{
 		KillPlayer(PLAYER_DEATH_TYPE_EXPLODE);
 	}

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -1943,8 +1943,8 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 {
 	float				fps = gFramesPerSecondFrac, oldFPS, oldFPSFrac, terrainY;
 	OGLPoint3D			oldCoord;
-	OGLVector2D			aimVec, deltaVec, accVec;
-	OGLMatrix3x3		m;
+	//OGLVector2D			aimVec, deltaVec, accVec;
+	//OGLMatrix3x3		m;
 	static OGLPoint2D origin = { 0,0 };
 	int					numPasses, pass;
 	Boolean				killed = false;
@@ -1973,7 +1973,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Bool
 		theNode->Rot.y -= sens; // Set rotate view (view follows robot rot) with analogControl (mouse)
 
 
-		float	strafe, movement;
+		float	strafe = 0.0f, movement = 0.0f;
 
 		// We are using the A or D keys (strafing):
 		if(gPlayerInfo.strafeControlX) {

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -1959,7 +1959,7 @@ Boolean				killed = false;
 				/* DO PLAYER-RELATIVE CONTROLS */
 				/*******************************/
 
-	if (gGamePrefs.playerRelControls)
+	if (gGamePrefs.playerRelControls) // (Doesnt seem to be the case for fpv VR mode)
 	{
 		float	r,sens;
 
@@ -2045,10 +2045,12 @@ Boolean				killed = false;
 			{
 				float	turnSpeed;
 
-				if (theNode->Speed2D > 400.0f)					// if walking fast then decrease the turn sensitivity
-					turnSpeed = 8;
+				if (theNode->Speed2D > 400.0f)					// tweaked numbers for fpv
+					turnSpeed = 20;
 				else
-					turnSpeed = 15;
+					turnSpeed = 7;
+
+				// Still have to figure out why it all goes crazy when player is standing still and turning on himself
 
 				TurnObjectTowardTarget(theNode, &gCoord, gCoord.x + aimVec.x, gCoord.z + aimVec.y, turnSpeed, false);
 			}

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -1965,8 +1965,8 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 
 		// analogControlX is mouse only now
 		sens = gPlayerInfo.analogControlX * fps * CONTROL_SENSITIVITY_PR_TURN;
-		if (theNode->Speed2D > 400.0f)												// turning less sensitive if walking
-			sens *= .5f;
+		
+		sens *= 0.5f; // sensitivity for turning camera (horizontally)
 
 		rotation = theNode->Rot.y -= sens; // Set rotate view (view follows robot rot) with analogControl (mouse)
 
@@ -2021,74 +2021,74 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 	/*******************************/
 	/* DO CAMERA-RELATIVE CONTROLS */
 	/*******************************/
-	else // UNUSED for VR for now
-	{
-		/* ROTATE ANALOG ACCELERATION VECTOR BASED ON CAMERA POS & APPLY TO DELTA */
+	//else // UNUSED for VR for now
+	//{
+	//	/* ROTATE ANALOG ACCELERATION VECTOR BASED ON CAMERA POS & APPLY TO DELTA */
 
-		if ((gPlayerInfo.analogControlX == 0.0f) && (gPlayerInfo.analogControlZ == 0.0f))	// see if not acceling
-		{
-			theNode->AccelVector.x = theNode->AccelVector.y = 0;
-		}
-		else
-		{
-			OGLMatrix3x3_SetRotateAboutPoint(&m, &origin, gPlayerToCameraAngle);			// make a 2D rotation matrix camera-rel
-			theNode->AccelVector.x = gPlayerInfo.analogControlX;
-			theNode->AccelVector.y = gPlayerInfo.analogControlZ;
-			//			OGLVector2D_Normalize(&theNode->AccelVector, &theNode->AccelVector);
-			OGLVector2D_Transform(&theNode->AccelVector, &m, &theNode->AccelVector);		// rotate the acceleration vector
-
-
-						/* APPLY ACCELERATION TO DELTAS */
-
-			if (theNode->StatusBits & STATUS_BIT_ONGROUND)
-			{
-				gDelta.x += theNode->AccelVector.x * (CONTROL_SENSITIVITY * (1.1f - gPlayerSlipperyFactor) * fps);
-				gDelta.z += theNode->AccelVector.y * (CONTROL_SENSITIVITY * (1.1f - gPlayerSlipperyFactor) * fps);
-			}
-			else
-			{
-				gDelta.x += theNode->AccelVector.x * (CONTROL_SENSITIVITY_AIR * fps);
-				gDelta.z += theNode->AccelVector.y * (CONTROL_SENSITIVITY_AIR * fps);
-			}
-		}
+	//	if ((gPlayerInfo.analogControlX == 0.0f) && (gPlayerInfo.analogControlZ == 0.0f))	// see if not acceling
+	//	{
+	//		theNode->AccelVector.x = theNode->AccelVector.y = 0;
+	//	}
+	//	else
+	//	{
+	//		OGLMatrix3x3_SetRotateAboutPoint(&m, &origin, gPlayerToCameraAngle);			// make a 2D rotation matrix camera-rel
+	//		theNode->AccelVector.x = gPlayerInfo.analogControlX;
+	//		theNode->AccelVector.y = gPlayerInfo.analogControlZ;
+	//		//			OGLVector2D_Normalize(&theNode->AccelVector, &theNode->AccelVector);
+	//		OGLVector2D_Transform(&theNode->AccelVector, &m, &theNode->AccelVector);		// rotate the acceleration vector
 
 
+	//					/* APPLY ACCELERATION TO DELTAS */
 
-		/**********************************************************/
-		/* TURN PLAYER TO AIM DIRECTION OF ACCELERATION OR MOTION */
-		/**********************************************************/
-		//
-		// Depending on how slippery the terrain is, we aim toward the direction
-		// of motion or the direction of acceleration.  We'll use the gPlayerSlipperyFactor value
-		// to average an aim vector between the two.
-		//
+	//		if (theNode->StatusBits & STATUS_BIT_ONGROUND)
+	//		{
+	//			gDelta.x += theNode->AccelVector.x * (CONTROL_SENSITIVITY * (1.1f - gPlayerSlipperyFactor) * fps);
+	//			gDelta.z += theNode->AccelVector.y * (CONTROL_SENSITIVITY * (1.1f - gPlayerSlipperyFactor) * fps);
+	//		}
+	//		else
+	//		{
+	//			gDelta.x += theNode->AccelVector.x * (CONTROL_SENSITIVITY_AIR * fps);
+	//			gDelta.z += theNode->AccelVector.y * (CONTROL_SENSITIVITY_AIR * fps);
+	//		}
+	//	}
 
-		if ((aimMode != AIM_MODE_NONE) && (theNode->Speed2D > 0.0f))
-		{
-			FastNormalizeVector2D(gDelta.x, gDelta.z, &deltaVec, true);
-			FastNormalizeVector2D(theNode->AccelVector.x, theNode->AccelVector.y, &accVec, true);
 
-			aimVec.x = deltaVec.x * (1.0f - gPlayerSlipperyFactor) + (accVec.x * gPlayerSlipperyFactor);
-			aimVec.y = deltaVec.y * (1.0f - gPlayerSlipperyFactor) + (accVec.y * gPlayerSlipperyFactor);
 
-			if (aimMode == AIM_MODE_REVERSE)
-				TurnObjectTowardTarget(theNode, &gCoord, gCoord.x - aimVec.x, gCoord.z - aimVec.y, 8.0f, false);
-			else
-				if (aimMode == AIM_MODE_NORMAL)
-				{
-					float	turnSpeed;
+	//	/**********************************************************/
+	//	/* TURN PLAYER TO AIM DIRECTION OF ACCELERATION OR MOTION */
+	//	/**********************************************************/
+	//	//
+	//	// Depending on how slippery the terrain is, we aim toward the direction
+	//	// of motion or the direction of acceleration.  We'll use the gPlayerSlipperyFactor value
+	//	// to average an aim vector between the two.
+	//	//
 
-					if (theNode->Speed2D > 400.0f)					// tweaked numbers for fpv
-						turnSpeed = 20;
-					else
-						turnSpeed = 7;
+	//	if ((aimMode != AIM_MODE_NONE) && (theNode->Speed2D > 0.0f))
+	//	{
+	//		FastNormalizeVector2D(gDelta.x, gDelta.z, &deltaVec, true);
+	//		FastNormalizeVector2D(theNode->AccelVector.x, theNode->AccelVector.y, &accVec, true);
 
-					// Still have to figure out why it all goes crazy when player is standing still and turning on himself
+	//		aimVec.x = deltaVec.x * (1.0f - gPlayerSlipperyFactor) + (accVec.x * gPlayerSlipperyFactor);
+	//		aimVec.y = deltaVec.y * (1.0f - gPlayerSlipperyFactor) + (accVec.y * gPlayerSlipperyFactor);
 
-					TurnObjectTowardTarget(theNode, &gCoord, gCoord.x + aimVec.x, gCoord.z + aimVec.y, turnSpeed, false);
-				}
-		}
-	}
+	//		if (aimMode == AIM_MODE_REVERSE)
+	//			TurnObjectTowardTarget(theNode, &gCoord, gCoord.x - aimVec.x, gCoord.z - aimVec.y, 8.0f, false);
+	//		else
+	//			if (aimMode == AIM_MODE_NORMAL)
+	//			{
+	//				float	turnSpeed;
+
+	//				if (theNode->Speed2D > 400.0f)					// tweaked numbers for fpv
+	//					turnSpeed = 20;
+	//				else
+	//					turnSpeed = 7;
+
+	//				// Still have to figure out why it all goes crazy when player is standing still and turning on himself
+
+	//				TurnObjectTowardTarget(theNode, &gCoord, gCoord.x + aimVec.x, gCoord.z + aimVec.y, turnSpeed, false);
+	//			}
+	//	}
+	//}
 
 	/* CALC SPEED */
 

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -267,6 +267,9 @@ int		i;
 	gTimeSinceLastShoot = 10;
 	gResetJumpJet = true;
 	gExplodePlayerAfterElectrocute = false;
+
+	// Make player invisble: 
+	newObj->StatusBits |= STATUS_BIT_HIDDEN;
 }
 
 

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -15,60 +15,60 @@
 /*    PROTOTYPES            */
 /****************************/
 
-static void MovePlayerRobot_JumpJet(ObjNode* theNode);
-static void MovePlayerRobot_Jump(ObjNode* theNode);
-static void MovePlayerRobot_Punch(ObjNode* theNode);
-static void MovePlayerRobot_PickupAndDeposit(ObjNode* theNode);
-static void MovePlayerRobot_PickupAndHoldGun(ObjNode* theNode);
-static void MovePlayerRobot_Drink(ObjNode* theNode);
-static void MovePlayerRobot_RideZip(ObjNode* theNode);
-static void MovePlayerRobot_ClimbInto(ObjNode* theNode);
-static void MovePlayerRobot_ShotFromCannon(ObjNode* theNode);
-static void MovePlayerRobot_BumperCar(ObjNode* theNode);
-static void MovePlayerRobot_GrabbedByStrongMan(ObjNode* theNode);
-static void MovePlayerRobot_RocketSled(ObjNode* theNode);
-static void MovePlayerRobot_Fall_BottomlessPit(ObjNode* theNode);
-static void MovePlayerRobot_Drilled(ObjNode* theNode);
+static void MovePlayerRobot_JumpJet(ObjNode *theNode);
+static void MovePlayerRobot_Jump(ObjNode *theNode);
+static void MovePlayerRobot_Punch(ObjNode *theNode);
+static void MovePlayerRobot_PickupAndDeposit(ObjNode *theNode);
+static void MovePlayerRobot_PickupAndHoldGun(ObjNode *theNode);
+static void MovePlayerRobot_Drink(ObjNode *theNode);
+static void MovePlayerRobot_RideZip(ObjNode *theNode);
+static void MovePlayerRobot_ClimbInto(ObjNode *theNode);
+static void MovePlayerRobot_ShotFromCannon(ObjNode *theNode);
+static void MovePlayerRobot_BumperCar(ObjNode *theNode);
+static void MovePlayerRobot_GrabbedByStrongMan(ObjNode *theNode);
+static void MovePlayerRobot_RocketSled(ObjNode *theNode);
+static void MovePlayerRobot_Fall_BottomlessPit(ObjNode *theNode);
+static void MovePlayerRobot_Drilled(ObjNode *theNode);
 
-static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrain);
-static void CheckPunchCollision(ObjNode* player);
-static void CheckPlayerActionControls(ObjNode* theNode);
-static void DoRobotFrictionAndGravity(ObjNode* theNode, float friction);
-static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Boolean useBBoxForTerrain);
-static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode);
-static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode);
-static void MovePlayerRobot_Stand(ObjNode* theNode);
-static void MovePlayerRobot_Walk(ObjNode* theNode);
-static void MovePlayerRobot_Fall(ObjNode* theNode);
-static void MovePlayerRobot_Grabbed(ObjNode* theNode);
-static void MovePlayerRobot_Flattened(ObjNode* theNode);
-static void MovePlayerRobot_Charging(ObjNode* theNode);
-static void MovePlayerRobot_Zapped(ObjNode* theNode);
-static void MovePlayerRobot_Drowned(ObjNode* theNode);
-static void MovePlayerRobot_Thrown(ObjNode* theNode);
-static void MovePlayerRobot_GotHit(ObjNode* theNode);
-static void MovePlayerRobot_Accordian(ObjNode* theNode);
-static void MovePlayerRobot_ChangeWeapon(ObjNode* theNode);
-static void MovePlayerRobot_Bubble(ObjNode* theNode);
-static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode* theNode);
-static void MovePlayerRobot_SuckedIntoWell(ObjNode* theNode);
-static void MovePlayerRobot_RideZip(ObjNode* theNode);
-static void MovePlayerRobot_Throw(ObjNode* theNode);
-static void MovePlayerRobot_BellySlide(ObjNode* theNode);
+static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrain);
+static void CheckPunchCollision(ObjNode *player);
+static void CheckPlayerActionControls(ObjNode *theNode);
+static void DoRobotFrictionAndGravity(ObjNode *theNode, float friction);
+static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Boolean useBBoxForTerrain);
+static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode);
+static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode);
+static void MovePlayerRobot_Stand(ObjNode *theNode);
+static void MovePlayerRobot_Walk(ObjNode *theNode);
+static void MovePlayerRobot_Fall(ObjNode *theNode);
+static void MovePlayerRobot_Grabbed(ObjNode *theNode);
+static void MovePlayerRobot_Flattened(ObjNode *theNode);
+static void MovePlayerRobot_Charging(ObjNode *theNode);
+static void MovePlayerRobot_Zapped(ObjNode *theNode);
+static void MovePlayerRobot_Drowned(ObjNode *theNode);
+static void MovePlayerRobot_Thrown(ObjNode *theNode);
+static void MovePlayerRobot_GotHit(ObjNode *theNode);
+static void MovePlayerRobot_Accordian(ObjNode *theNode);
+static void MovePlayerRobot_ChangeWeapon(ObjNode *theNode);
+static void MovePlayerRobot_Bubble(ObjNode *theNode);
+static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode *theNode);
+static void MovePlayerRobot_SuckedIntoWell(ObjNode *theNode);
+static void MovePlayerRobot_RideZip(ObjNode *theNode);
+static void MovePlayerRobot_Throw(ObjNode *theNode);
+static void MovePlayerRobot_BellySlide(ObjNode *theNode);
 
-static float CalcWalkAnimSpeed(ObjNode* theNode);
-static void StartJumpJet(ObjNode* theNode);
-static void EndJumpJet(ObjNode* theNode);
-static void UpdateJumpJetParticles(ObjNode* theNode);
-static void UpdatePlayerAutoAim(ObjNode* player);
+static float CalcWalkAnimSpeed(ObjNode *theNode);
+static void StartJumpJet(ObjNode *theNode);
+static void EndJumpJet(ObjNode *theNode);
+static void UpdateJumpJetParticles(ObjNode *theNode);
+static void UpdatePlayerAutoAim(ObjNode *player);
 
-static Boolean IsPlayerDoingWalkAnim(ObjNode* theNode);
-static Boolean IsPlayerDoingStandAnim(ObjNode* theNode);
+static Boolean IsPlayerDoingWalkAnim(ObjNode *theNode);
+static Boolean IsPlayerDoingStandAnim(ObjNode *theNode);
 
-static void TurnPlayerTowardPunchable(ObjNode* player);
+static void TurnPlayerTowardPunchable(ObjNode *player);
 
-static void DoPlayerMagnetSkiing(ObjNode* player);
-static void EndMagnetSkiing(ObjNode* player, Boolean crash);
+static void DoPlayerMagnetSkiing(ObjNode *player);
+static void EndMagnetSkiing(ObjNode *player, Boolean crash);
 static void VerifyTargetPickup(void);
 
 
@@ -137,8 +137,8 @@ u_short			gPlayerTileAttribs;
 
 OGLVector3D		gPreCollisionDelta;
 
-ObjNode* gTargetPickup = nil;
-ObjNode* gCannon = nil;
+ObjNode *gTargetPickup = nil;
+ObjNode *gCannon = nil;
 
 float			gPlayerBottomOff = 0;
 
@@ -171,9 +171,9 @@ float	gCurrentMaxSpeed = PLAYER_NORMAL_MAX_SPEED;
 //			rotY = rotation to assign to player if oldObj is nil.
 //
 
-void InitPlayer_Robot(OGLPoint3D* where, float rotY)
+void InitPlayer_Robot(OGLPoint3D *where, float rotY)
 {
-	ObjNode* newObj;
+	ObjNode *newObj;
 	float	y;
 	int		i;
 
@@ -181,7 +181,7 @@ void InitPlayer_Robot(OGLPoint3D* where, float rotY)
 
 	y = FindHighestCollisionAtXZ(where->x, where->z, CTYPE_MISC | CTYPE_TERRAIN);
 
-	if (gLevelNum == LEVEL_NUM_BLOBBOSS)
+	if(gLevelNum == LEVEL_NUM_BLOBBOSS)
 		y += 5000.0f;				// blob boss, player falls from above
 	else
 		y += -gObjectGroupBBoxList[MODEL_GROUP_SKELETONBASE + SKELETON_TYPE_OTTO][0].min.y * PLAYER_DEFAULT_SCALE + 5.0f;	// offset y so foot is on ground
@@ -223,7 +223,7 @@ void InitPlayer_Robot(OGLPoint3D* where, float rotY)
 	/* CREATE HAND OBJECTS */
 	/***********************/
 
-	for (i = 0; i < (GLOBAL_ObjType_FlameGunHand - GLOBAL_ObjType_OttoLeftHand + 1); i++)
+	for(i = 0; i < (GLOBAL_ObjType_FlameGunHand - GLOBAL_ObjType_OttoLeftHand + 1); i++)
 	{
 		BG3D_SphereMapGeomteryMaterial(MODEL_GROUP_GLOBAL, GLOBAL_ObjType_OttoLeftHand + i, 0, MULTI_TEXTURE_COMBINE_ADD, SPHEREMAP_SObjType_DarkDusk);	// set this model to be sphere mapped
 	}
@@ -275,9 +275,9 @@ void InitPlayer_Robot(OGLPoint3D* where, float rotY)
 
 /******************** MOVE PLAYER: ROBOT ***********************/
 
-void MovePlayer_Robot(ObjNode* theNode)
+void MovePlayer_Robot(ObjNode *theNode)
 {
-	static void(*myMoveTable[])(ObjNode*) =
+	static void(*myMoveTable[])(ObjNode *) =
 	{
 		MovePlayerRobot_Stand,							// standing
 		MovePlayerRobot_Walk,							// walking
@@ -318,7 +318,7 @@ void MovePlayer_Robot(ObjNode* theNode)
 
 	GetObjectInfo(theNode);
 
-	if (gPlayerHasLanded)								// inc thrust timer since assume no thrust this frame
+	if(gPlayerHasLanded)								// inc thrust timer since assume no thrust this frame
 	{
 		gTimeSinceLastThrust += gFramesPerSecondFrac;
 		gTimeSinceLastShoot += gFramesPerSecondFrac;
@@ -336,7 +336,7 @@ void MovePlayer_Robot(ObjNode* theNode)
 
 	/* SEE IF SHOULD FREEZE CAMERA */
 
-	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMPJET)		// dont move camera from during jump-jet
+	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMPJET)		// dont move camera from during jump-jet
 		gFreezeCameraFromXZ = false; // Do move it in VR
 	else
 		gFreezeCameraFromXZ = false;
@@ -346,7 +346,7 @@ void MovePlayer_Robot(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: STAND ***********************/
 
-static void MovePlayerRobot_Stand(ObjNode* theNode)
+static void MovePlayerRobot_Stand(ObjNode *theNode)
 {
 	theNode->Rot.x = 0;								// make sure this is correct
 	theNode->Rot.z = 0;								// make sure this is correct
@@ -355,17 +355,17 @@ static void MovePlayerRobot_Stand(ObjNode* theNode)
 
 	UpdatePlayerAutoAim(theNode);
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NORMAL, false))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NORMAL, false))
 		goto update;
 
 
 	/* SEE IF SHOULD WALK */
 
-	if (IsPlayerDoingStandAnim(theNode))
+	if(IsPlayerDoingStandAnim(theNode))
 	{
 		float	animSpeed = CalcWalkAnimSpeed(theNode);
 
-		if ((animSpeed > WALK_STAND_THRESHOLD) && (gTimeSinceLastThrust < THRUST_TIMER))
+		if((animSpeed > WALK_STAND_THRESHOLD) && (gTimeSinceLastThrust < THRUST_TIMER))
 			SetPlayerWalkAnim(theNode);
 	}
 
@@ -388,7 +388,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: WALK ***********************/
 
-static void MovePlayerRobot_Walk(ObjNode* theNode)
+static void MovePlayerRobot_Walk(ObjNode *theNode)
 {
 	theNode->Rot.x = 0;								// make sure this is correct
 	theNode->Rot.z = 0;								// make sure this is correct
@@ -402,7 +402,7 @@ static void MovePlayerRobot_Walk(ObjNode* theNode)
 
 	UpdatePlayerAutoAim(theNode);
 
-	if ((gPlayerInfo.analogControlX == 0.0f) &&			// if no user control, do heavy friction
+	if((gPlayerInfo.analogControlX == 0.0f) &&			// if no user control, do heavy friction
 		(gPlayerInfo.analogControlZ == 0.0f))
 	{
 		DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
@@ -412,17 +412,17 @@ static void MovePlayerRobot_Walk(ObjNode* theNode)
 		DoRobotFrictionAndGravity(theNode, PLAYER_DEFAULT_FRICTION);
 	}
 
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NORMAL, false))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NORMAL, false))
 		goto update;
 
 
 	/* SEE IF SHOULD STAND */
 
-	if (IsPlayerDoingWalkAnim(theNode))
+	if(IsPlayerDoingWalkAnim(theNode))
 	{
 		float	animSpeed = CalcWalkAnimSpeed(theNode);
 
-		if ((animSpeed < WALK_STAND_THRESHOLD) || (gTimeSinceLastThrust > THRUST_TIMER))
+		if((animSpeed < WALK_STAND_THRESHOLD) || (gTimeSinceLastThrust > THRUST_TIMER))
 			SetPlayerStandAnim(theNode, 8);
 		else
 			theNode->Skeleton->AnimSpeed = animSpeed * .004f;
@@ -438,7 +438,7 @@ update:
 
 /******************* CALC WALK ANIM SPEED **********************/
 
-static float CalcWalkAnimSpeed(ObjNode* theNode)
+static float CalcWalkAnimSpeed(ObjNode *theNode)
 {
 	float	animSpeed, accSpeed;
 
@@ -449,7 +449,7 @@ static float CalcWalkAnimSpeed(ObjNode* theNode)
 
 				/* NOW ACCOUNT FOR GIANT SCALE */
 
-	if (theNode->Scale.x != PLAYER_DEFAULT_SCALE)
+	if(theNode->Scale.x != PLAYER_DEFAULT_SCALE)
 	{
 		float	f;
 
@@ -463,7 +463,7 @@ static float CalcWalkAnimSpeed(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: JUMP ***********************/
 
-static void MovePlayerRobot_Jump(ObjNode* theNode)
+static void MovePlayerRobot_Jump(ObjNode *theNode)
 {
 	Byte	aimMode;
 
@@ -474,30 +474,30 @@ static void MovePlayerRobot_Jump(ObjNode* theNode)
 
 	/* MOVE PLAYER */
 
-	if (gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
+	if(gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
 		aimMode = AIM_MODE_NONE;
 	else
 		aimMode = AIM_MODE_NORMAL;
 
 	DoRobotFrictionAndGravity(theNode, PLAYER_AIR_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, aimMode, false))
+	if(DoPlayerMovementAndCollision(theNode, aimMode, false))
 		goto update;
 
 
-	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)		// only bother if still in Fall anim
+	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)		// only bother if still in Fall anim
 	{
 		/* SEE IF LANDED */
 
-		if (theNode->StatusBits & STATUS_BIT_ONGROUND)
+		if(theNode->StatusBits & STATUS_BIT_ONGROUND)
 		{
 			SetPlayerStandAnim(theNode, 8);
 		}
 
 		/* SEE IF FALLING */
 		else
-			if (gDelta.y < 0.0f)
+			if(gDelta.y < 0.0f)
 			{
-				if (gDoJumpJetAtApex)							// see if we wanted to jet @ the apex
+				if(gDoJumpJetAtApex)							// see if we wanted to jet @ the apex
 					StartJumpJet(theNode);
 				else
 					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);
@@ -513,7 +513,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: PICKUP AND DEPOSIT ***********************/
 
-static void MovePlayerRobot_PickupAndDeposit(ObjNode* theNode)
+static void MovePlayerRobot_PickupAndDeposit(ObjNode *theNode)
 {
 	OGLMatrix4x4	m, m2;
 
@@ -525,13 +525,13 @@ static void MovePlayerRobot_PickupAndDeposit(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
 	/* KEEP AIMED AT TARGET */
 
-	if (gTargetPickup && (!theNode->IsHoldingPickup))
+	if(gTargetPickup && (!theNode->IsHoldingPickup))
 	{
 		TurnObjectTowardTarget(theNode, &gCoord, gTargetPickup->Coord.x,
 			gTargetPickup->Coord.z, 9.0, false);
@@ -539,29 +539,29 @@ static void MovePlayerRobot_PickupAndDeposit(ObjNode* theNode)
 
 	/* SEE IF DONE */
 
-	if (theNode->Skeleton->AnimHasStopped)										// go to stand when done with anim
+	if(theNode->Skeleton->AnimHasStopped)										// go to stand when done with anim
 		SetPlayerStandAnim(theNode, 2);
 
-	if (theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPDEPOSIT)				// if anim has changed then finish things up with the pickup
+	if(theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPDEPOSIT)				// if anim has changed then finish things up with the pickup
 	{
-		if (theNode->IsHoldingPickup)											// if we had it then add it
+		if(theNode->IsHoldingPickup)											// if we had it then add it
 		{
 			theNode->IsHoldingPickup = false;
 
-			if (gTargetPickup != nil)											// verify that there's a target
+			if(gTargetPickup != nil)											// verify that there's a target
 			{
 				AddPowerupToInventory(gTargetPickup);
 				PlayEffect3D(EFFECT_WEAPONDEPOSIT, &gCoord);
 
 
-				if (gTargetPickup->CType & CTYPE_BLOBPOW) 				 			// special check for blobule powerups
+				if(gTargetPickup->CType & CTYPE_BLOBPOW) 				 			// special check for blobule powerups
 					DisableHelpType(HELP_MESSAGE_SLIMEBALLS);						// picked up a blob so dont need to help on this anymore
 
-				if (gTargetPickup->POWRegenerate)							// if regeneratable, then just hide until needed
+				if(gTargetPickup->POWRegenerate)							// if regeneratable, then just hide until needed
 				{
 					gTargetPickup->MoveCall = MovePowerup;					// restore the Move Call
 					gTargetPickup->StatusBits |= STATUS_BIT_HIDDEN;
-					if (gTargetPickup->ShadowNode)							// and hide shadow
+					if(gTargetPickup->ShadowNode)							// and hide shadow
 						gTargetPickup->ShadowNode->StatusBits |= STATUS_BIT_HIDDEN;
 
 					gTargetPickup->CType = 0;								// no collision when hidden
@@ -587,7 +587,7 @@ update:
 	/* UPDATE THE PICKUP */
 	/*********************/
 
-	if (gTargetPickup && theNode->IsHoldingPickup)
+	if(gTargetPickup && theNode->IsHoldingPickup)
 	{
 		gTargetPickup->MoveCall = nil;										// make sure the pickup no longer has control if itself
 
@@ -612,13 +612,13 @@ update:
 // For picking up holdable objects when left hand is currently empty - item goes into hand instead of being deposited.
 //
 
-static void MovePlayerRobot_PickupAndHoldGun(ObjNode* theNode)
+static void MovePlayerRobot_PickupAndHoldGun(ObjNode *theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
 	VerifyTargetPickup();
 
-	if (gTargetPickup)														// if not holding it yet, then keep aimed at it
+	if(gTargetPickup)														// if not holding it yet, then keep aimed at it
 	{
 		TurnObjectTowardTarget(theNode, &gCoord, gTargetPickup->Coord.x,
 			gTargetPickup->Coord.z, 9.0, false);
@@ -628,31 +628,31 @@ static void MovePlayerRobot_PickupAndHoldGun(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
 	/* SEE IF DONE */
 
-	if (theNode->Skeleton->AnimHasStopped)
+	if(theNode->Skeleton->AnimHasStopped)
 		SetPlayerStandAnim(theNode, 4);
 
 
 	/* SEE IF GRAB IT NOW */
 
-	if (gTargetPickup)
+	if(gTargetPickup)
 	{
-		if ((theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPANDHOLDGUN) || (theNode->IsHoldingPickup))
+		if((theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPANDHOLDGUN) || (theNode->IsHoldingPickup))
 		{
 			PlayEffect3D(EFFECT_WEAPONCLICK, &gCoord);
 
 			AddPowerupToInventory(gTargetPickup);
 			theNode->IsHoldingPickup = false;
 
-			if (gTargetPickup->POWRegenerate)							// if regeneratable, then just hide until needed
+			if(gTargetPickup->POWRegenerate)							// if regeneratable, then just hide until needed
 			{
 				gTargetPickup->StatusBits |= STATUS_BIT_HIDDEN;
-				if (gTargetPickup->ShadowNode)							// and hide shadow
+				if(gTargetPickup->ShadowNode)							// and hide shadow
 					gTargetPickup->ShadowNode->StatusBits |= STATUS_BIT_HIDDEN;
 				gTargetPickup->CType = 0;
 			}
@@ -673,7 +673,7 @@ update:
 // Does both the pickup and holding of the magnet
 //
 
-static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode* theNode)
+static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode *theNode)
 {
 	VerifyTargetPickup();
 
@@ -682,7 +682,7 @@ static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode* theNode)
 	/* MOVE DURING HOLDING PART */
 	/****************************/
 
-	if (theNode->IsHoldingPickup)
+	if(theNode->IsHoldingPickup)
 	{
 		DoPlayerMagnetSkiing(theNode);
 	}
@@ -697,13 +697,13 @@ static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode* theNode)
 
 		gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 		DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-		if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+		if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 			goto update;
 
 
 		/* KEEP AIMED AT TARGET */
 
-		if (gTargetPickup && (!theNode->IsHoldingPickup))
+		if(gTargetPickup && (!theNode->IsHoldingPickup))
 		{
 			TurnObjectTowardTarget(theNode, &gCoord, gTargetPickup->Coord.x,
 				gTargetPickup->Coord.z, 9.0, false);
@@ -712,7 +712,7 @@ static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode* theNode)
 
 	/* SEE IF DONE */
 
-	if (theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPANDHOLDMAGNET)			// if anim has changed then finish things up with the pickup
+	if(theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPANDHOLDMAGNET)			// if anim has changed then finish things up with the pickup
 	{
 		EndMagnetSkiing(theNode, false);
 	}
@@ -729,7 +729,7 @@ update:
 	/* UPDATE THE MAGNET */
 	/*********************/
 
-	if (gTargetPickup && theNode->IsHoldingPickup)
+	if(gTargetPickup && theNode->IsHoldingPickup)
 	{
 		static const OGLPoint3D	off = { 0,0,10 };
 		OGLPoint3D	p1, p2;
@@ -762,9 +762,9 @@ update:
 
 static void VerifyTargetPickup(void)
 {
-	if (gTargetPickup)
+	if(gTargetPickup)
 	{
-		if (gTargetPickup->CType == INVALID_NODE_FLAG)
+		if(gTargetPickup->CType == INVALID_NODE_FLAG)
 		{
 			gTargetPickup = nil;
 		}
@@ -775,7 +775,7 @@ static void VerifyTargetPickup(void)
 
 /******************** MOVE PLAYER ROBOT: CHANGE WEAPON ***********************/
 
-static void MovePlayerRobot_ChangeWeapon(ObjNode* theNode)
+static void MovePlayerRobot_ChangeWeapon(ObjNode *theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -783,13 +783,13 @@ static void MovePlayerRobot_ChangeWeapon(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
 
 	/* SEE IF DONE */
 
-	if (theNode->Skeleton->AnimHasStopped)
+	if(theNode->Skeleton->AnimHasStopped)
 	{
 		SetPlayerStandAnim(theNode, 3);
 	}
@@ -801,7 +801,7 @@ static void MovePlayerRobot_ChangeWeapon(ObjNode* theNode)
 	// pulling out a new gun (ChangeWeapon anim flag)
 	//
 
-	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON
+	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON
 		&& !theNode->ChangeWeapon)
 	{
 		CheckWeaponChangeControls(theNode);
@@ -815,7 +815,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: SUCKED INTO WELL ***********************/
 
-static void MovePlayerRobot_SuckedIntoWell(ObjNode* theNode)
+static void MovePlayerRobot_SuckedIntoWell(ObjNode *theNode)
 {
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
@@ -840,7 +840,7 @@ static void MovePlayerRobot_SuckedIntoWell(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: PUNCH ***********************/
 
-static void MovePlayerRobot_Punch(ObjNode* theNode)
+static void MovePlayerRobot_Punch(ObjNode *theNode)
 {
 
 	/* MOVE PLAYER */
@@ -849,12 +849,12 @@ static void MovePlayerRobot_Punch(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
 	/* SEE IF CHECK FOR PUNCH COLLISION */
 
-	if (theNode->PunchCanHurt)
+	if(theNode->PunchCanHurt)
 	{
 		CheckPunchCollision(theNode);
 
@@ -863,7 +863,7 @@ static void MovePlayerRobot_Punch(ObjNode* theNode)
 
 	/* SEE IF SHOULD STAND */
 
-	if (theNode->Skeleton->AnimHasStopped)
+	if(theNode->Skeleton->AnimHasStopped)
 	{
 		SetPlayerStandAnim(theNode, 8);
 	}
@@ -878,19 +878,19 @@ update:
 
 /******************** MOVE PLAYER ROBOT: THROW ***********************/
 
-static void MovePlayerRobot_Throw(ObjNode* theNode)
+static void MovePlayerRobot_Throw(ObjNode *theNode)
 {
 
 	/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
 	/* SEE IF CHECK FOR RELEASE DART */
 
-	if (theNode->ThrowDartNow)
+	if(theNode->ThrowDartNow)
 	{
 		ThrowDart(theNode);
 		theNode->ThrowDartNow = false;
@@ -899,7 +899,7 @@ static void MovePlayerRobot_Throw(ObjNode* theNode)
 
 	/* SEE IF SHOULD STAND */
 
-	if (theNode->Skeleton->AnimHasStopped)
+	if(theNode->Skeleton->AnimHasStopped)
 	{
 		SetPlayerStandAnim(theNode, 4);
 	}
@@ -915,9 +915,9 @@ update:
 
 /*********************** TURN PLAYER TOWARD PUNCHABLE ****************************/
 
-static void TurnPlayerTowardPunchable(ObjNode* player)
+static void TurnPlayerTowardPunchable(ObjNode *player)
 {
-	ObjNode* thisNode, * nearest;
+	ObjNode *thisNode, *nearest;
 	float	ex, ey, ez, dist, bestDist, maxDist;
 
 	bestDist = 10000000;
@@ -931,7 +931,7 @@ static void TurnPlayerTowardPunchable(ObjNode* player)
 
 	do
 	{
-		if (thisNode->HitByWeaponHandler[WEAPON_TYPE_FIST] == nil)					// only look for punchables
+		if(thisNode->HitByWeaponHandler[WEAPON_TYPE_FIST] == nil)					// only look for punchables
 			goto next;
 
 		ex = thisNode->Coord.x;									// get obj coords
@@ -939,7 +939,7 @@ static void TurnPlayerTowardPunchable(ObjNode* player)
 		ez = thisNode->Coord.z;
 
 		dist = CalcDistance(gCoord.x, gCoord.z, ex, ez);
-		if ((dist < bestDist) && (dist < maxDist))				// see if best dist & close enough
+		if((dist < bestDist) && (dist < maxDist))				// see if best dist & close enough
 		{
 			bestDist = dist;
 			nearest = thisNode;
@@ -947,12 +947,12 @@ static void TurnPlayerTowardPunchable(ObjNode* player)
 
 	next:
 		thisNode = thisNode->NextNode;							// next target node
-	} while (thisNode != nil);
+	} while(thisNode != nil);
 
 
 	/* THERE IS SOMETHING THERE */
 
-	if (nearest)
+	if(nearest)
 	{
 		TurnObjectTowardTarget(player, &gCoord, nearest->Coord.x,
 			nearest->Coord.z, 6.0, false);
@@ -964,25 +964,25 @@ static void TurnPlayerTowardPunchable(ObjNode* player)
 
 /******************** MOVE PLAYER ROBOT: JUMPJET ***********************/
 
-static void MovePlayerRobot_JumpJet(ObjNode* theNode)
+static void MovePlayerRobot_JumpJet(ObjNode *theNode)
 {
 
 
 	/* MOVE PLAYER */
 
-	if (DoPlayerMovementAndCollision_JumpJet(theNode))
+	if(DoPlayerMovementAndCollision_JumpJet(theNode))
 		goto update;
 
 
 	/* SEE IF LANDED */
 
-	if (theNode->StatusBits & STATUS_BIT_ONGROUND)
+	if(theNode->StatusBits & STATUS_BIT_ONGROUND)
 	{
 		SetPlayerStandAnim(theNode, 7);
 	}
 	/* SEE IF DONE WITH JUMP-JET ANIM */
 	else
-		if (theNode->Skeleton->AnimHasStopped || GetNewNeedState(kNeed_Jump))
+		if(theNode->Skeleton->AnimHasStopped || GetNewNeedState(kNeed_Jump))
 		{
 			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);		// make fall anim
 		}
@@ -993,7 +993,7 @@ static void MovePlayerRobot_JumpJet(ObjNode* theNode)
 
 update:
 
-	if ((theNode->Skeleton->AnimNum != PLAYER_ANIM_JUMPJET) &&
+	if((theNode->Skeleton->AnimNum != PLAYER_ANIM_JUMPJET) &&
 		(theNode->Skeleton->AnimNum != PLAYER_ANIM_GIANTJUMPJET))		// if anything changed, then make sure to cleanup
 	{
 		EndJumpJet(theNode);
@@ -1008,7 +1008,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: FALL ***********************/
 
-static void MovePlayerRobot_Fall(ObjNode* theNode)
+static void MovePlayerRobot_Fall(ObjNode *theNode)
 {
 	float	oldDY = gDelta.y;
 	Byte	aimMode;
@@ -1019,7 +1019,7 @@ static void MovePlayerRobot_Fall(ObjNode* theNode)
 			/* SEE IF FALLING IN A BOTTOMLESS PIT DEATH */
 			/********************************************/
 
-	if (gPlayerFellIntoBottomlessPit)
+	if(gPlayerFellIntoBottomlessPit)
 	{
 		MovePlayerRobot_Fall_BottomlessPit(theNode);
 		return;
@@ -1032,13 +1032,13 @@ static void MovePlayerRobot_Fall(ObjNode* theNode)
 
 	/* MOVE PLAYER */
 
-	if (gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
+	if(gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
 		aimMode = AIM_MODE_NONE;
 	else
 		aimMode = AIM_MODE_NORMAL;
 
 	DoRobotFrictionAndGravity(theNode, PLAYER_AIR_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, aimMode, false))
+	if(DoPlayerMovementAndCollision(theNode, aimMode, false))
 		goto update;
 
 
@@ -1046,14 +1046,14 @@ static void MovePlayerRobot_Fall(ObjNode* theNode)
 	/* SEE IF LANDED */
 	/*****************/
 
-	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_FALL)						// only bother if still in Fall anim
+	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_FALL)						// only bother if still in Fall anim
 	{
-		if ((theNode->StatusBits & STATUS_BIT_ONGROUND) || (gPlayerInfo.distToFloor < 10.0f))
+		if((theNode->StatusBits & STATUS_BIT_ONGROUND) || (gPlayerInfo.distToFloor < 10.0f))
 		{
 
 			/* DO ANIM AFTER LANDED */
 
-			switch (theNode->Skeleton->AnimNum)
+			switch(theNode->Skeleton->AnimNum)
 			{
 			case	PLAYER_ANIM_BUMPERCAR:								// check if trigger put us in bumper car
 				break;
@@ -1062,21 +1062,21 @@ static void MovePlayerRobot_Fall(ObjNode* theNode)
 				SetPlayerStandAnim(theNode, 8);						// default to standing when landing
 			}
 
-			if (oldDY < -300.0f)											// if landing fast enough
+			if(oldDY < -300.0f)											// if landing fast enough
 			{
 				PlayEffect3D(EFFECT_METALLAND, &gCoord);					// play hard land sound
 
 						/* MAKE DEFORMATION WAVE */
 
-				if (gLevelNum == LEVEL_NUM_BLOB)
+				if(gLevelNum == LEVEL_NUM_BLOB)
 				{
-					if (gPlayerInfo.distToFloor < 10.0f)						// if on terrain, then deform
+					if(gPlayerInfo.distToFloor < 10.0f)						// if on terrain, then deform
 					{
 						DeformationType		defData;
 
 						defData.type = DEFORMATION_TYPE_RADIALWAVE;
 						defData.amplitude = oldDY * -.08f * gPlayerInfo.scaleRatio;
-						if (defData.amplitude > 1000.0f)
+						if(defData.amplitude > 1000.0f)
 							defData.amplitude = 1000.0f;
 
 						defData.radius = 0;
@@ -1103,7 +1103,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: FALL BOTTOMLESS PIT ***********************/
 
-static void MovePlayerRobot_Fall_BottomlessPit(ObjNode* theNode)
+static void MovePlayerRobot_Fall_BottomlessPit(ObjNode *theNode)
 {
 	float	fps = gFramesPerSecondFrac;
 
@@ -1112,10 +1112,10 @@ static void MovePlayerRobot_Fall_BottomlessPit(ObjNode* theNode)
 
 	/* SEE IF TIME FOR DEATH EXIT TRANSITION */
 
-	if (gDeathTimer > 0.0f)
+	if(gDeathTimer > 0.0f)
 	{
 		gDeathTimer -= fps;					// dec timer
-		if (gDeathTimer <= 0.0f)								// see if time to reset player
+		if(gDeathTimer <= 0.0f)								// see if time to reset player
 			StartDeathExit(0);
 	}
 
@@ -1136,7 +1136,7 @@ static void MovePlayerRobot_Fall_BottomlessPit(ObjNode* theNode)
 // no control and we don't care about a lot of things in the collision.
 //
 
-static void MovePlayerRobot_Thrown(ObjNode* theNode)
+static void MovePlayerRobot_Thrown(ObjNode *theNode)
 {
 	float	fps = gFramesPerSecondFrac;
 
@@ -1156,7 +1156,7 @@ static void MovePlayerRobot_Thrown(ObjNode* theNode)
 	/* COLLISION */
 
 	HandleCollisions(theNode, CTYPE_MISC | CTYPE_TERRAIN | CTYPE_FENCE, -.6);
-	if (theNode->StatusBits & STATUS_BIT_ONGROUND)								// once on ground then stop
+	if(theNode->StatusBits & STATUS_BIT_ONGROUND)								// once on ground then stop
 	{
 		theNode->Rot.x = 0;
 
@@ -1176,7 +1176,7 @@ static void MovePlayerRobot_Thrown(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: GRABBED ***********************/
 
-static void MovePlayerRobot_Grabbed(ObjNode* theNode)
+static void MovePlayerRobot_Grabbed(ObjNode *theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1187,7 +1187,7 @@ static void MovePlayerRobot_Grabbed(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: GRABBED BY STRONGMAN ***********************/
 
-static void MovePlayerRobot_GrabbedByStrongMan(ObjNode* theNode)
+static void MovePlayerRobot_GrabbedByStrongMan(ObjNode *theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1198,7 +1198,7 @@ static void MovePlayerRobot_GrabbedByStrongMan(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: DRILLED ***********************/
 
-static void MovePlayerRobot_Drilled(ObjNode* theNode)
+static void MovePlayerRobot_Drilled(ObjNode *theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1213,17 +1213,17 @@ static void MovePlayerRobot_Drilled(ObjNode* theNode)
 // when in H20
 //
 
-static void MovePlayerRobot_Zapped(ObjNode* theNode)
+static void MovePlayerRobot_Zapped(ObjNode *theNode)
 {
-	if (gLevelNum == LEVEL_NUM_BLOBBOSS)				// if blob boss then must have fallen into water/ground to bob
+	if(gLevelNum == LEVEL_NUM_BLOBBOSS)				// if blob boss then must have fallen into water/ground to bob
 		gCoord.y = GetTerrainY(gCoord.x, gCoord.z);
 
 	theNode->ZappedTimer -= gFramesPerSecondFrac;					// dec timer
-	if (theNode->ZappedTimer <= 0.0f)
+	if(theNode->ZappedTimer <= 0.0f)
 	{
 		/* KILL THE PLAYER */
 
-		if (gExplodePlayerAfterElectrocute)
+		if(gExplodePlayerAfterElectrocute)
 			KillPlayer(PLAYER_DEATH_TYPE_EXPLODE);
 		else
 			KillPlayer(PLAYER_DEATH_TYPE_DROWN);
@@ -1235,9 +1235,9 @@ static void MovePlayerRobot_Zapped(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: DROWNED ***********************/
 
-static void MovePlayerRobot_Drowned(ObjNode* theNode)
+static void MovePlayerRobot_Drowned(ObjNode *theNode)
 {
-	if (gPlayerInfo.waterPatch == -1)						// see if have patch, otherwise use terrain y
+	if(gPlayerInfo.waterPatch == -1)						// see if have patch, otherwise use terrain y
 		gCoord.y = GetTerrainY(gCoord.x, gCoord.z);
 	else
 		gCoord.y = gWaterBBox[gPlayerInfo.waterPatch].max.y;
@@ -1245,10 +1245,10 @@ static void MovePlayerRobot_Drowned(ObjNode* theNode)
 
 	/* SEE IF END */
 
-	if (gDeathTimer > 0.0f)
+	if(gDeathTimer > 0.0f)
 	{
 		gDeathTimer -= gFramesPerSecondFrac;					// dec timer
-		if (gDeathTimer <= 0.0f)								// see if time to reset player
+		if(gDeathTimer <= 0.0f)								// see if time to reset player
 		{
 			StartDeathExit(0);
 		}
@@ -1260,7 +1260,7 @@ static void MovePlayerRobot_Drowned(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: FLATTENED ***********************/
 
-static void MovePlayerRobot_Flattened(ObjNode* theNode)
+static void MovePlayerRobot_Flattened(ObjNode *theNode)
 {
 	u_long	wasOnGround = theNode->StatusBits & STATUS_BIT_ONGROUND;
 
@@ -1270,13 +1270,13 @@ static void MovePlayerRobot_Flattened(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_DEFAULT_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
 	/* PLAY BOUNCE SFX */
 
-	if ((theNode->StatusBits & STATUS_BIT_ONGROUND) && (!wasOnGround))
+	if((theNode->StatusBits & STATUS_BIT_ONGROUND) && (!wasOnGround))
 	{
 		//		if (gDelta.y > 20.0f)
 		PlayEffect3D(EFFECT_PLAYERCLANG, &gCoord);
@@ -1284,7 +1284,7 @@ static void MovePlayerRobot_Flattened(ObjNode* theNode)
 
 
 	gPlayerInfo.knockDownTimer -= gFramesPerSecondFrac;
-	if (gPlayerInfo.knockDownTimer <= 0.0f)
+	if(gPlayerInfo.knockDownTimer <= 0.0f)
 	{
 		SetPlayerStandAnim(theNode, 4);
 		gPlayerInfo.invincibilityTimer = 1.0f;
@@ -1298,7 +1298,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: BELLY SLIDE ***********************/
 
-static void MovePlayerRobot_BellySlide(ObjNode* theNode)
+static void MovePlayerRobot_BellySlide(ObjNode *theNode)
 {
 	theNode->Rot.x = theNode->Rot.z = 0;
 
@@ -1306,12 +1306,12 @@ static void MovePlayerRobot_BellySlide(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_DEFAULT_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
 	gPlayerInfo.knockDownTimer -= gFramesPerSecondFrac;
-	if ((gPlayerInfo.knockDownTimer <= 0.0f) || (theNode->Speed2D <= 0.0f))
+	if((gPlayerInfo.knockDownTimer <= 0.0f) || (theNode->Speed2D <= 0.0f))
 	{
 		SetPlayerStandAnim(theNode, 3);
 		gPlayerInfo.invincibilityTimer = 1.0f;
@@ -1325,7 +1325,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: CHARGING ***********************/
 
-static void MovePlayerRobot_Charging(ObjNode* theNode)
+static void MovePlayerRobot_Charging(ObjNode *theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1333,15 +1333,15 @@ static void MovePlayerRobot_Charging(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
 
 	/* SEE IF DISCHARGE SUPERNOVA */
 
-	if (gPlayerInfo.superNovaStatic)						// if this obj exists then we're still charging
+	if(gPlayerInfo.superNovaStatic)						// if this obj exists then we're still charging
 	{
-		if (!GetNeedState(kNeed_Shoot))
+		if(!GetNeedState(kNeed_Shoot))
 		{
 			DischargeSuperNova();							// attempt to discharge it
 		}
@@ -1355,7 +1355,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: GOT HIT ***********************/
 
-static void MovePlayerRobot_GotHit(ObjNode* theNode)
+static void MovePlayerRobot_GotHit(ObjNode *theNode)
 {
 	float	f;
 
@@ -1365,18 +1365,18 @@ static void MovePlayerRobot_GotHit(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 
-	if (theNode->StatusBits & STATUS_BIT_ONGROUND)
+	if(theNode->StatusBits & STATUS_BIT_ONGROUND)
 		f = PLAYER_HEAVY_FRICTION;
 	else
 		f = PLAYER_AIR_FRICTION;
 	DoRobotFrictionAndGravity(theNode, f);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_REVERSE, true))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_REVERSE, true))
 		goto update;
 
 
 	/* SEE IF DONE */
 
-	if (theNode->Skeleton->AnimHasStopped)
+	if(theNode->Skeleton->AnimHasStopped)
 	{
 		gPlayerInfo.invincibilityTimer = 2.0f;
 		SetPlayerStandAnim(theNode, 5);
@@ -1392,7 +1392,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: ACCORDIAN ***********************/
 
-static void MovePlayerRobot_Accordian(ObjNode* theNode)
+static void MovePlayerRobot_Accordian(ObjNode *theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1405,14 +1405,14 @@ static void MovePlayerRobot_Accordian(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
 	/* SEE IF DONE */
 
 	theNode->AccordianTimer -= gFramesPerSecondFrac;
-	if (theNode->AccordianTimer <= 0.0f)
+	if(theNode->AccordianTimer <= 0.0f)
 	{
 		gPlayerInfo.invincibilityTimer = 1.3f;
 		SetPlayerStandAnim(theNode, 3);
@@ -1428,7 +1428,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: BUBBLE ***********************/
 
-static void MovePlayerRobot_Bubble(ObjNode* theNode)
+static void MovePlayerRobot_Bubble(ObjNode *theNode)
 {
 	float	y;
 
@@ -1436,7 +1436,7 @@ static void MovePlayerRobot_Bubble(ObjNode* theNode)
 
 	y = GetTerrainY(gCoord.x, gCoord.z) + 300.0f;
 	gDelta.y = y - gCoord.y;
-	if (gDelta.y > 0.0f)
+	if(gDelta.y > 0.0f)
 		gDelta.y *= 2.0f;					// float up faster than float down
 
 
@@ -1452,7 +1452,7 @@ static void MovePlayerRobot_Bubble(ObjNode* theNode)
 
 	/* UPDATE BUBBLE */
 
-	if (gSoapBubble)
+	if(gSoapBubble)
 	{
 		gSoapBubble->Coord = gCoord;
 		UpdateObjectTransforms(gSoapBubble);
@@ -1463,7 +1463,7 @@ static void MovePlayerRobot_Bubble(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: DRINK ***********************/
 
-static void MovePlayerRobot_Drink(ObjNode* theNode)
+static void MovePlayerRobot_Drink(ObjNode *theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1471,13 +1471,13 @@ static void MovePlayerRobot_Drink(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_DEFAULT_FRICTION);
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
 	/* SEE IF DONE */
 
-	if (theNode->Skeleton->AnimHasStopped)
+	if(theNode->Skeleton->AnimHasStopped)
 	{
 		gPlayerInfo.growMode = GROWTH_MODE_GROW;
 		gPlayerInfo.giantTimer = 12.0f;
@@ -1492,7 +1492,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: RIDE ZIP ***********************/
 
-static void MovePlayerRobot_RideZip(ObjNode* theNode)
+static void MovePlayerRobot_RideZip(ObjNode *theNode)
 {
 	float	r = theNode->Rot.y;
 
@@ -1510,7 +1510,7 @@ static void MovePlayerRobot_RideZip(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: CLIMB INTO ***********************/
 
-static void MovePlayerRobot_ClimbInto(ObjNode* theNode)
+static void MovePlayerRobot_ClimbInto(ObjNode *theNode)
 {
 	theNode->Skeleton->AnimSpeed = 1.6;
 
@@ -1518,7 +1518,7 @@ static void MovePlayerRobot_ClimbInto(ObjNode* theNode)
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	gDelta.x = gDelta.y = gDelta.z = 0.0f;
-	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
+	if(DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, true))
 		goto update;
 
 
@@ -1530,7 +1530,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: SHOT FROM CANNON ***********************/
 
-static void MovePlayerRobot_ShotFromCannon(ObjNode* theNode)
+static void MovePlayerRobot_ShotFromCannon(ObjNode *theNode)
 {
 	float	fps = gFramesPerSecondFrac;
 
@@ -1546,7 +1546,7 @@ static void MovePlayerRobot_ShotFromCannon(ObjNode* theNode)
 
 	/* SEE IF HIT GROUND */
 
-	if ((gCoord.y + theNode->BBox.min.y) <= GetTerrainY(gCoord.x, gCoord.z))
+	if((gCoord.y + theNode->BBox.min.y) <= GetTerrainY(gCoord.x, gCoord.z))
 	{
 		SetSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_BELLYSLIDE);
 		gPlayerInfo.knockDownTimer = 1.0f;
@@ -1564,7 +1564,7 @@ static void MovePlayerRobot_ShotFromCannon(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: BUMPER CAR ***********************/
 
-static void MovePlayerRobot_BumperCar(ObjNode* theNode)
+static void MovePlayerRobot_BumperCar(ObjNode *theNode)
 {
 
 
@@ -1576,7 +1576,7 @@ static void MovePlayerRobot_BumperCar(ObjNode* theNode)
 
 /******************** MOVE PLAYER ROBOT: ROCKETSLED ***********************/
 
-static void MovePlayerRobot_RocketSled(ObjNode* theNode)
+static void MovePlayerRobot_RocketSled(ObjNode *theNode)
 {
 
 
@@ -1592,17 +1592,17 @@ static void MovePlayerRobot_RocketSled(ObjNode* theNode)
 
 /************************ UPDATE PLAYER: ROBOT ***************************/
 
-void UpdatePlayer_Robot(ObjNode* theNode)
+void UpdatePlayer_Robot(ObjNode *theNode)
 {
 	float fps = gFramesPerSecondFrac;
 
 	/* VERIFY BOTTOMLESS PIT */
 
-	if (gLevelNum == LEVEL_NUM_CLOUD)
+	if(gLevelNum == LEVEL_NUM_CLOUD)
 	{
-		if ((gCoord.y + theNode->BBox.min.y) < (GetTerrainY2(gCoord.x, gCoord.z) - 30.0f))		// if player is below terrain's real height
+		if((gCoord.y + theNode->BBox.min.y) < (GetTerrainY2(gCoord.x, gCoord.z) - 30.0f))		// if player is below terrain's real height
 		{
-			if (GetTerrainY(gCoord.x, gCoord.z) == BOTTOMLESS_PIT_Y)							//  and if this is a bottomless pit zone
+			if(GetTerrainY(gCoord.x, gCoord.z) == BOTTOMLESS_PIT_Y)							//  and if this is a bottomless pit zone
 				KillPlayer(PLAYER_DEATH_TYPE_FALL);
 		}
 	}
@@ -1610,25 +1610,25 @@ void UpdatePlayer_Robot(ObjNode* theNode)
 
 	/* VERIFY ANIM INFO */
 
-	switch (theNode->Skeleton->AnimNum)
+	switch(theNode->Skeleton->AnimNum)
 	{
 	case	PLAYER_ANIM_STANDWITHGUN:
-		if (!gPlayerInfo.holdingGun)											// verify using correct stand anim
+		if(!gPlayerInfo.holdingGun)											// verify using correct stand anim
 			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STAND, 6.0);
 		break;
 
 	case	PLAYER_ANIM_STAND:
-		if (gPlayerInfo.holdingGun)
+		if(gPlayerInfo.holdingGun)
 			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STANDWITHGUN, 6.0);
 		break;
 
 	case	PLAYER_ANIM_WALKWITHGUN:
-		if (!gPlayerInfo.holdingGun)											// verify using correct walk anim
+		if(!gPlayerInfo.holdingGun)											// verify using correct walk anim
 			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALK, 9.0);
 		break;
 
 	case	PLAYER_ANIM_WALK:
-		if (gPlayerInfo.holdingGun)
+		if(gPlayerInfo.holdingGun)
 			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALKWITHGUN, 9.0);
 		break;
 
@@ -1637,7 +1637,7 @@ void UpdatePlayer_Robot(ObjNode* theNode)
 
 	/* UPDATE SPECIAL COLLISION INFO */
 
-	switch (theNode->Skeleton->AnimNum)
+	switch(theNode->Skeleton->AnimNum)
 	{
 	case	PLAYER_ANIM_ACCORDIAN:
 	case	PLAYER_ANIM_FLATTENED:
@@ -1654,7 +1654,7 @@ void UpdatePlayer_Robot(ObjNode* theNode)
 
 	/* UPDATE OBJECT AS LONG AS NOT BEING MATRIX CONTROLLED */
 
-	switch (theNode->Skeleton->AnimNum)
+	switch(theNode->Skeleton->AnimNum)
 	{
 	case	PLAYER_ANIM_GRABBED:
 	case	PLAYER_ANIM_GRABBED2:
@@ -1674,12 +1674,12 @@ void UpdatePlayer_Robot(ObjNode* theNode)
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);
 	theNode->Speed3D = CalcVectorLength(&gDelta);
 
-	if (theNode->Speed2D < gTargetMaxSpeed)					// if we're less than the target, then just reset current to target
+	if(theNode->Speed2D < gTargetMaxSpeed)					// if we're less than the target, then just reset current to target
 		gCurrentMaxSpeed = gTargetMaxSpeed;
 	else
-		if (gCurrentMaxSpeed > gTargetMaxSpeed)					// see if in overdrive, so readjust currnet
+		if(gCurrentMaxSpeed > gTargetMaxSpeed)					// see if in overdrive, so readjust currnet
 		{
-			if (theNode->Speed2D < gCurrentMaxSpeed)			// we're slower than Current, so adjust current down to us
+			if(theNode->Speed2D < gCurrentMaxSpeed)			// we're slower than Current, so adjust current down to us
 			{
 				gCurrentMaxSpeed = theNode->Speed2D;
 			}
@@ -1689,7 +1689,7 @@ void UpdatePlayer_Robot(ObjNode* theNode)
 
 	UpdatePlayerSparkles(theNode);
 
-	if (gPlayerInfo.burnTimer > 0.0f)
+	if(gPlayerInfo.burnTimer > 0.0f)
 	{
 		gPlayerInfo.burnTimer -= fps;
 		BurnSkeleton(theNode, 40.0f * gPlayerInfo.scaleRatio);
@@ -1707,7 +1707,7 @@ void UpdatePlayer_Robot(ObjNode* theNode)
 
 	/* CHECK FOR ACCIDENTAL SUPERNOVA DISCHARGE */
 
-	if ((theNode->Skeleton->AnimNum != PLAYER_ANIM_CHARGING) &&		// if we are not charging but we have a static object
+	if((theNode->Skeleton->AnimNum != PLAYER_ANIM_CHARGING) &&		// if we are not charging but we have a static object
 		(gPlayerInfo.superNovaStatic != nil))
 	{
 		DischargeSuperNova();
@@ -1719,16 +1719,16 @@ void UpdatePlayer_Robot(ObjNode* theNode)
 	gPlayerInfo.invincibilityTimer -= fps;
 
 
-	if (theNode->StatusBits & STATUS_BIT_ONGROUND)		// if on ground then reset jump jet
+	if(theNode->StatusBits & STATUS_BIT_ONGROUND)		// if on ground then reset jump jet
 		gResetJumpJet = true;
 }
 
 
 /********************* UPDATE ROBOT HANDS *************************/
 
-void UpdateRobotHands(ObjNode* theNode)
+void UpdateRobotHands(ObjNode *theNode)
 {
-	ObjNode* lhand, * rhand;
+	ObjNode *lhand, *rhand;
 	Boolean	holdingGun;
 	int		weaponType;
 
@@ -1736,7 +1736,7 @@ void UpdateRobotHands(ObjNode* theNode)
 	/* DETERMINE IF HOLDING GUN */
 	/****************************/
 
-	if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON) && (!theNode->ChangeWeapon))	// see if still holding old gun during weapon change
+	if((theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON) && (!theNode->ChangeWeapon))	// see if still holding old gun during weapon change
 	{
 		weaponType = gPlayerInfo.oldWeaponType;				// use old weapon Type
 		holdingGun = gPlayerInfo.wasHoldingGun;				// use old gun flag
@@ -1745,14 +1745,14 @@ void UpdateRobotHands(ObjNode* theNode)
 	{
 		holdingGun = gPlayerInfo.holdingGun;
 		weaponType = gPlayerInfo.currentWeaponType;
-		if (weaponType >= WEAPON_TYPE_FIST)							// verify it while we're here
+		if(weaponType >= WEAPON_TYPE_FIST)							// verify it while we're here
 			holdingGun = gPlayerInfo.holdingGun = false;
 	}
 
-	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_BUMPERCAR)		// don't show gun while driving bumper car
+	if(theNode->Skeleton->AnimNum == PLAYER_ANIM_BUMPERCAR)		// don't show gun while driving bumper car
 		holdingGun = false;
 	else
-		if (theNode->Skeleton->AnimNum == PLAYER_ANIM_BUBBLE)			// don't show gun while riding bubble
+		if(theNode->Skeleton->AnimNum == PLAYER_ANIM_BUBBLE)			// don't show gun while riding bubble
 			holdingGun = false;
 
 	/*****************************/
@@ -1764,10 +1764,10 @@ void UpdateRobotHands(ObjNode* theNode)
 
 	lhand->ColorFilter.a = rhand->ColorFilter.a = theNode->ColorFilter.a;	// match alpha fades
 
-	if (rhand && lhand)										// only update if both hands are legit
+	if(rhand && lhand)										// only update if both hands are legit
 	{
 
-		switch (theNode->Skeleton->AnimNum)
+		switch(theNode->Skeleton->AnimNum)
 		{
 			/* OPEN HANDS */
 
@@ -1778,15 +1778,15 @@ void UpdateRobotHands(ObjNode* theNode)
 		case	PLAYER_ANIM_BUBBLE:
 		case	PLAYER_ANIM_SITONLEDGE:
 		case	PLAYER_ANIM_DRILLED:
-			if (rhand->Type != GLOBAL_ObjType_OttoRightHand)
+			if(rhand->Type != GLOBAL_ObjType_OttoRightHand)
 			{
 				rhand->Type = GLOBAL_ObjType_OttoRightHand;
 				ResetDisplayGroupObject(rhand);
 			}
 
-			if (!holdingGun)
+			if(!holdingGun)
 			{
-				if (lhand->Type != GLOBAL_ObjType_OttoLeftHand)
+				if(lhand->Type != GLOBAL_ObjType_OttoLeftHand)
 				{
 					lhand->Type = GLOBAL_ObjType_OttoLeftHand;
 					ResetDisplayGroupObject(lhand);
@@ -1798,15 +1798,15 @@ void UpdateRobotHands(ObjNode* theNode)
 			/* FISTS */
 
 		default:
-			if (rhand->Type != GLOBAL_ObjType_OttoRightFist)
+			if(rhand->Type != GLOBAL_ObjType_OttoRightFist)
 			{
 				rhand->Type = GLOBAL_ObjType_OttoRightFist;
 				ResetDisplayGroupObject(rhand);
 			}
 
-			if (!holdingGun)
+			if(!holdingGun)
 			{
-				if (lhand->Type != GLOBAL_ObjType_OttoLeftFist)
+				if(lhand->Type != GLOBAL_ObjType_OttoLeftFist)
 				{
 					lhand->Type = GLOBAL_ObjType_OttoLeftFist;
 					ResetDisplayGroupObject(lhand);
@@ -1817,9 +1817,9 @@ void UpdateRobotHands(ObjNode* theNode)
 
 		/* GUN IN LEFT HAND */
 
-		if (holdingGun)
+		if(holdingGun)
 		{
-			if (lhand->Type != (GLOBAL_ObjType_PulseGunHand + weaponType))
+			if(lhand->Type != (GLOBAL_ObjType_PulseGunHand + weaponType))
 			{
 				lhand->Type = GLOBAL_ObjType_PulseGunHand + weaponType;
 				ResetDisplayGroupObject(lhand);
@@ -1852,7 +1852,7 @@ void UpdateRobotHands(ObjNode* theNode)
 //
 
 
-void UpdatePlayerMotionBlur(ObjNode* theNode)
+void UpdatePlayerMotionBlur(ObjNode *theNode)
 {
 	int		v, i;
 	static OGLColorRGBA color = { 0.6f, 0.6f, 1.0f, PLAYER_VAPOR_ALPHA };
@@ -1866,9 +1866,9 @@ void UpdatePlayerMotionBlur(ObjNode* theNode)
 	/* SEE IF SHOULD TO BLUR */
 	/*************************/
 
-	if (theNode->Skeleton->AnimNum != PLAYER_ANIM_JUMPJET)													// always blur when jump-jetting
+	if(theNode->Skeleton->AnimNum != PLAYER_ANIM_JUMPJET)													// always blur when jump-jetting
 	{
-		if (theNode->Speed3D < PLAYER_VAPOR_THRESHOLD)				// only add trail if going fast
+		if(theNode->Speed3D < PLAYER_VAPOR_THRESHOLD)				// only add trail if going fast
 			return;
 
 		/* DONT DO BLUR IF PLAYER IS MOVING AWAY FROM CAMERA */
@@ -1880,7 +1880,7 @@ void UpdatePlayerMotionBlur(ObjNode* theNode)
 			&viewVec);
 
 		dot = OGLVector3D_Dot(&playerVec, &viewVec);															// calc dot product to determine angle
-		if ((dot > .9f) || (dot < -.9f))
+		if((dot > .9f) || (dot < -.9f))
 			return;
 	}
 
@@ -1889,22 +1889,22 @@ void UpdatePlayerMotionBlur(ObjNode* theNode)
 	/* UPDATE THE BLUR */
 	/*******************/
 
-	for (v = 0; v < theNode->Skeleton->skeletonDefinition->NumBones; v++)
+	for(v = 0; v < theNode->Skeleton->skeletonDefinition->NumBones; v++)
 	{
 		FindCoordOfJoint(theNode, v, &p);
 
 		i = theNode->VaporTrails[v];							// get vaport trail #
 
-		if (VerifyVaporTrail(i, theNode, v))
+		if(VerifyVaporTrail(i, theNode, v))
 		{
-			if (v == 1)											// head has white trail
+			if(v == 1)											// head has white trail
 				AddToVaporTrail(&theNode->VaporTrails[v], &p, &color2);
 			else
 				AddToVaporTrail(&theNode->VaporTrails[v], &p, &color);
 		}
 		else
 		{
-			if (theNode->Speed3D > (PLAYER_VAPOR_THRESHOLD * 1.2f))				// only start new vapor if above the threshold by a good margin to avoid "popping"
+			if(theNode->Speed3D > (PLAYER_VAPOR_THRESHOLD * 1.2f))				// only start new vapor if above the threshold by a good margin to avoid "popping"
 				theNode->VaporTrails[v] = CreateNewVaporTrail(theNode, v, VAPORTRAIL_TYPE_COLORSTREAK, &p, &color, 1.0, 4.0, 20.0);
 		}
 	}
@@ -1914,11 +1914,11 @@ void UpdatePlayerMotionBlur(ObjNode* theNode)
 
 /******************* UPDATE PLAYER AUTO AIM ****************************/
 
-static void UpdatePlayerAutoAim(ObjNode* player)
+static void UpdatePlayerAutoAim(ObjNode *player)
 {
 	float	tx, tz;
 
-	if (gPlayerInfo.autoAimTimer <= 0.0f)
+	if(gPlayerInfo.autoAimTimer <= 0.0f)
 		return;
 
 	gPlayerInfo.autoAimTimer -= gFramesPerSecondFrac;			// dec timer
@@ -1939,7 +1939,7 @@ static void UpdatePlayerAutoAim(ObjNode* player)
 // OUTPUT: true if disabled or killed
 //
 
-static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Boolean useBBoxForTerrain)
+static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Boolean useBBoxForTerrain)
 {
 	float				fps = gFramesPerSecondFrac, oldFPS, oldFPSFrac, terrainY;
 	OGLPoint3D			oldCoord;
@@ -1949,7 +1949,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 	int					numPasses, pass;
 	Boolean				killed = false;
 
-	if (gPlayerInfo.analogControlX || gPlayerInfo.analogControlZ || gPlayerInfo.strafeControlX)	// if player is attempting some control then reset this timer
+	if(gPlayerInfo.analogControlX || gPlayerInfo.analogControlZ || gPlayerInfo.strafeControlX)	// if player is attempting some control then reset this timer
 	{
 		gTimeSinceLastThrust = 0;
 		gForceCameraAlignment = false;								// now that player is moving us, dont force auto-align
@@ -1961,13 +1961,13 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 	/* DO PLAYER-RELATIVE CONTROLS */
 	/*******************************/
 
-	if (true) // (Gives better mouse control?) Seems to prevent player from turning when colliding 
+	if(true) // (Gives better mouse control?) Seems to prevent player from turning when colliding 
 	{
 		float	sens;
 
 		// analogControlX is mouse only now
 		sens = gPlayerInfo.analogControlX * fps * CONTROL_SENSITIVITY_PR_TURN;
-		
+
 		sens *= 0.5f; // sensitivity for turning camera (horizontally)
 
 		theNode->Rot.y -= sens; // Set rotate view (view follows robot rot) with analogControl (mouse)
@@ -1976,17 +1976,17 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 		float	strafe, movement;
 
 		// We are using the A or D keys (strafing):
-		if (gPlayerInfo.strafeControlX) {
+		if(gPlayerInfo.strafeControlX) {
 			// We are only strafing (no forward nor backward):
-			if (gPlayerInfo.analogControlZ == 0) {
+			if(gPlayerInfo.analogControlZ == 0) {
 				strafe = theNode->Rot.y + PI / 2;
 			}
 			// We are moving forward:
-			else if (gPlayerInfo.analogControlZ < 0) {
+			else if(gPlayerInfo.analogControlZ < 0) {
 				strafe = theNode->Rot.y - sin(gPlayerInfo.strafeControlX);
 			}
 			// We are moving backward:
-			else if (gPlayerInfo.analogControlZ > 0) {
+			else if(gPlayerInfo.analogControlZ > 0) {
 				strafe = theNode->Rot.y + sin(gPlayerInfo.strafeControlX);
 			}
 		}
@@ -1999,7 +1999,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 		theNode->AccelVector.y = cos(strafe);
 
 
-		if (!gPlayerInfo.analogControlZ) {
+		if(!gPlayerInfo.analogControlZ) {
 			movement = gPlayerInfo.strafeControlX;
 		}
 		else {
@@ -2007,7 +2007,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 		}
 
 
-		if (theNode->StatusBits & STATUS_BIT_ONGROUND)
+		if(theNode->StatusBits & STATUS_BIT_ONGROUND)
 		{
 			gDelta.x += theNode->AccelVector.x * ((CONTROL_SENSITIVITY_PR * movement) * (1.1f - gPlayerSlipperyFactor) * fps);
 			gDelta.z += theNode->AccelVector.y * ((CONTROL_SENSITIVITY_PR * movement) * (1.1f - gPlayerSlipperyFactor) * fps);
@@ -2095,7 +2095,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 	/* CALC SPEED */
 
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);					// calc 2D speed value
-	if ((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
+	if((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
 	{
 	}
 	else
@@ -2104,7 +2104,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 		gDelta.x = gDelta.z = 0;
 	}
 
-	if (theNode->Speed2D > gCurrentMaxSpeed)						// see if limit top speed
+	if(theNode->Speed2D > gCurrentMaxSpeed)						// see if limit top speed
 	{
 		float	tweak;
 
@@ -2134,7 +2134,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 
 	fps = gFramesPerSecondFrac;
 
-	for (pass = 0; pass < numPasses; pass++)
+	for(pass = 0; pass < numPasses; pass++)
 	{
 		float	dx, dy, dz;
 
@@ -2147,9 +2147,9 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 		dy = gDelta.y;
 		dz = gDelta.z;
 
-		if (theNode->MPlatform)						// see if factor in moving platform
+		if(theNode->MPlatform)						// see if factor in moving platform
 		{
-			ObjNode* plat = theNode->MPlatform;
+			ObjNode *plat = theNode->MPlatform;
 			dx += plat->Delta.x;
 			dy += plat->Delta.y;
 			dz += plat->Delta.z;
@@ -2166,7 +2166,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 		/* DO OBJECT COLLISION DETECT */
 		/******************************/
 
-		if (DoRobotCollisionDetect(theNode, useBBoxForTerrain))
+		if(DoRobotCollisionDetect(theNode, useBBoxForTerrain))
 			killed = true;
 
 
@@ -2198,12 +2198,13 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 }
 
 
+
 /******************* DO PLAYER MOVEMENT AND COLLISION DETECT: JUMP JET *********************/
 //
 // OUTPUT: true if disabled or killed
 //
 
-static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode)
+static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
 {
 	float				fps = gFramesPerSecondFrac, oldFPS, oldFPSFrac;
 	OGLVector3D			accVec;
@@ -2232,7 +2233,7 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode)
 				/* CALC SPEED */
 
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);					// calc 2D speed value
-	if ((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))	// check for weird NaN bug
+	if((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))	// check for weird NaN bug
 	{
 	}
 	else
@@ -2259,7 +2260,7 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode)
 
 	fps = gFramesPerSecondFrac;
 
-	for (pass = 0; pass < numPasses; pass++)
+	for(pass = 0; pass < numPasses; pass++)
 	{
 		float	dx, dy, dz;
 
@@ -2275,15 +2276,15 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode)
 
 		/* MOVE IT */
 
-		if (theNode->JumpJetEnginesOff)
+		if(theNode->JumpJetEnginesOff)
 		{
 			gPlayerInfo.jumpJetSpeed -= JUMP_JET_DECELERATION * fps;					// decelerate jump jet speed
-			if (gPlayerInfo.jumpJetSpeed < 0.0f)
+			if(gPlayerInfo.jumpJetSpeed < 0.0f)
 				gPlayerInfo.jumpJetSpeed = 0;
 		}
 		else
 		{
-			if (theNode->Skeleton->AnimNum == PLAYER_ANIM_GIANTJUMPJET)
+			if(theNode->Skeleton->AnimNum == PLAYER_ANIM_GIANTJUMPJET)
 				gPlayerInfo.jumpJetSpeed += JUMP_JET_ACCELERATION_GIANT * fps;					// accelerate jump jet speed as giant
 			else
 				gPlayerInfo.jumpJetSpeed += JUMP_JET_ACCELERATION * fps;					// accelerate jump jet speed
@@ -2324,12 +2325,12 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode)
 	/* DO JUMP-JET FIST COLLISION */
 	/******************************/
 
-	if (!killed)
+	if(!killed)
 	{
 		static const OGLPoint3D fistOff = { 0,-50,0 };
 		OGLPoint3D	fistCoord1, fistCoord2;
 		int			i;
-		ObjNode* hitObj;
+		ObjNode *hitObj;
 
 		/* CALC COORD TO TEST */
 
@@ -2342,15 +2343,15 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode)
 
 		/* SEE IF HIT ANYTHING */
 
-		if (DoSimpleBoxCollision(fistCoord1.y + 30.0f, fistCoord1.y - 30.0f, fistCoord1.x - 30.0f, fistCoord1.x + 30.0f,
+		if(DoSimpleBoxCollision(fistCoord1.y + 30.0f, fistCoord1.y - 30.0f, fistCoord1.x - 30.0f, fistCoord1.x + 30.0f,
 			fistCoord1.z + 30.0f, fistCoord1.z - 30.0f, CTYPE_MISC | CTYPE_ENEMY))
 		{
-			for (i = 0; i < gNumCollisions; i++)										// scan hits for a handler
+			for(i = 0; i < gNumCollisions; i++)										// scan hits for a handler
 			{
 				hitObj = gCollisionList[i].objectPtr;									// get hit ObjNode
-				if (hitObj)
+				if(hitObj)
 				{
-					if (hitObj->HitByJumpJetHandler)									// see if there is a handler
+					if(hitObj->HitByJumpJetHandler)									// see if there is a handler
 						(hitObj->HitByJumpJetHandler)(hitObj);							// call the handler
 				}
 			}
@@ -2366,7 +2367,7 @@ static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode)
 // OUTPUT: true if disabled or killed
 //
 
-static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode)
+static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
 {
 	float				fps = gFramesPerSecondFrac;
 	OGLVector2D			aimVec, deltaVec, accVec;
@@ -2379,7 +2380,7 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode)
 	/* DO PLAYER-RELATIVE CONTROLS */
 	/*******************************/
 
-	if (gGamePrefs.playerRelControls)
+	if(gGamePrefs.playerRelControls)
 	{
 		float	r;
 
@@ -2388,7 +2389,7 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode)
 		theNode->AccelVector.x = sin(r);
 		theNode->AccelVector.y = cos(r);
 
-		if (theNode->StatusBits & STATUS_BIT_ONGROUND)
+		if(theNode->StatusBits & STATUS_BIT_ONGROUND)
 		{
 			gDelta.x += theNode->AccelVector.x * (CONTROL_SENSITIVITY_PR * gPlayerInfo.analogControlZ) * (1.1f - gPlayerSlipperyFactor);
 			gDelta.z += theNode->AccelVector.y * (CONTROL_SENSITIVITY_PR * gPlayerInfo.analogControlZ) * (1.1f - gPlayerSlipperyFactor);
@@ -2443,7 +2444,7 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode)
 	/* CALC SPEED */
 
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);					// calc 2D speed value
-	if ((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
+	if((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
 	{
 	}
 	else
@@ -2452,7 +2453,7 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode)
 		gDelta.x = gDelta.z = 0;
 	}
 
-	if (theNode->Speed2D > MAX_BUBBLE_SPEED)						// see if limit top speed
+	if(theNode->Speed2D > MAX_BUBBLE_SPEED)						// see if limit top speed
 	{
 		float	tweak;
 
@@ -2480,7 +2481,7 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode)
 	// if we need to pop the bubble
 	//
 
-	if (DoSimpleBoxCollision(gCoord.y + gSoapBubble->TopOff, gCoord.y + gSoapBubble->BottomOff,
+	if(DoSimpleBoxCollision(gCoord.y + gSoapBubble->TopOff, gCoord.y + gSoapBubble->BottomOff,
 		gCoord.x + gSoapBubble->LeftOff, gCoord.x + gSoapBubble->RightOff,
 		gCoord.z + gSoapBubble->FrontOff, gCoord.z + gSoapBubble->BackOff,
 		CTYPE_MISC | CTYPE_ENEMY | CTYPE_TRIGGER))
@@ -2494,7 +2495,7 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode)
 
 	oldRadius = theNode->BoundingSphereRadius;								// tweak the radius for this
 	theNode->BoundingSphereRadius = gSoapBubble->BBox.max.x;
-	if (DoFenceCollision(theNode) || hit)
+	if(DoFenceCollision(theNode) || hit)
 	{
 		PopSoapBubble(gSoapBubble);
 	}
@@ -2509,7 +2510,7 @@ static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode)
 // Applies friction to the gDeltas
 //
 
-static void DoRobotFrictionAndGravity(ObjNode* theNode, float friction)
+static void DoRobotFrictionAndGravity(ObjNode *theNode, float friction)
 {
 	OGLVector2D	v;
 	float	x, z, fps;
@@ -2522,8 +2523,8 @@ static void DoRobotFrictionAndGravity(ObjNode* theNode, float friction)
 
 	gDelta.y -= gGravity * fps;					// add gravity
 
-	if (gDelta.y < 0.0f)							// if falling, keep dy at least -1.0 to avoid collision jitter on platforms
-		if (gDelta.y > (-20.0f * fps))
+	if(gDelta.y < 0.0f)							// if falling, keep dy at least -1.0 to avoid collision jitter on platforms
+		if(gDelta.y > (-20.0f * fps))
 			gDelta.y = (-20.0f * fps);
 
 
@@ -2534,16 +2535,16 @@ static void DoRobotFrictionAndGravity(ObjNode* theNode, float friction)
 	// Dont do friction if player is pressing controls
 	//
 
-	if (true) // Always player relative controls in VR
+	if(true) // Always player relative controls in VR
 	{
-		/* Removed "analogControlX" from here as that is for mouse movement only. If we don't 
+		/* Removed "analogControlX" from here as that is for mouse movement only. If we don't
 		   do friction when there is mouse movement we get the bug of moving mouse = always move (ref fordcars/OttoMatic-VR#7) */
-		if (gPlayerInfo.analogControlZ || gPlayerInfo.strafeControlX)	// if there is any player control then no friction
+		if(gPlayerInfo.analogControlZ || gPlayerInfo.strafeControlX)	// if there is any player control then no friction
 			return;
 	}
 	else										// with player relative controls, do heavier friction in some cases
 	{
-		switch (theNode->Skeleton->AnimNum)
+		switch(theNode->Skeleton->AnimNum)
 		{
 		case	PLAYER_ANIM_STAND:
 		case	PLAYER_ANIM_WALK:
@@ -2568,35 +2569,35 @@ static void DoRobotFrictionAndGravity(ObjNode* theNode, float friction)
 	x = -v.x * friction;						// make counter-motion vector
 	z = -v.y * friction;
 
-	if (gDelta.x < 0.0f)						// decelerate against vector
+	if(gDelta.x < 0.0f)						// decelerate against vector
 	{
 		gDelta.x += x;
-		if (gDelta.x > 0.0f)					// see if sign changed
+		if(gDelta.x > 0.0f)					// see if sign changed
 			gDelta.x = 0;
 	}
 	else
-		if (gDelta.x > 0.0f)
+		if(gDelta.x > 0.0f)
 		{
 			gDelta.x += x;
-			if (gDelta.x < 0.0f)
+			if(gDelta.x < 0.0f)
 				gDelta.x = 0;
 		}
 
-	if (gDelta.z < 0.0f)
+	if(gDelta.z < 0.0f)
 	{
 		gDelta.z += z;
-		if (gDelta.z > 0.0f)
+		if(gDelta.z > 0.0f)
 			gDelta.z = 0;
 	}
 	else
-		if (gDelta.z > 0.0f)
+		if(gDelta.z > 0.0f)
 		{
 			gDelta.z += z;
-			if (gDelta.z < 0.0f)
+			if(gDelta.z < 0.0f)
 				gDelta.z = 0;
 		}
 
-	if ((gDelta.x == 0.0f) && (gDelta.z == 0.0f))
+	if((gDelta.x == 0.0f) && (gDelta.z == 0.0f))
 	{
 		theNode->Speed2D = 0;
 	}
@@ -2613,10 +2614,10 @@ static void DoRobotFrictionAndGravity(ObjNode* theNode, float friction)
 // OUTPUT: true = disabled/killed
 //
 
-static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrain)
+static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrain)
 {
 	short		i;
-	ObjNode* hitObj;
+	ObjNode *hitObj;
 	unsigned long	ctype;
 	u_char		sides;
 	float		distToFloor, terrainY, fps = gFramesPerSecondFrac;
@@ -2638,7 +2639,7 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 			// this also sets the ONGROUND status bit if on a solid object.
 			//
 
-	if (useBBoxForTerrain)
+	if(useBBoxForTerrain)
 		theNode->BottomOff = theNode->BBox.min.y;
 	else
 		theNode->BottomOff = gPlayerBottomOff;
@@ -2648,16 +2649,16 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 	/* SCAN FOR INTERESTING STUFF */
 
 
-	for (i = 0; i < gNumCollisions; i++)
+	for(i = 0; i < gNumCollisions; i++)
 	{
-		if (gCollisionList[i].type == COLLISION_TYPE_OBJ)
+		if(gCollisionList[i].type == COLLISION_TYPE_OBJ)
 		{
 			hitObj = gCollisionList[i].objectPtr;				// get ObjNode of this collision
 
-			if (hitObj->CType == INVALID_NODE_FLAG)				// see if has since become invalid
+			if(hitObj->CType == INVALID_NODE_FLAG)				// see if has since become invalid
 				continue;
 
-			if (gCollisionList[i].sides & SIDE_BITS_BOTTOM)		// if bottom hit then set gPlayerSlipperyFactor from the object's friction value
+			if(gCollisionList[i].sides & SIDE_BITS_BOTTOM)		// if bottom hit then set gPlayerSlipperyFactor from the object's friction value
 				gPlayerSlipperyFactor = hitObj->Friction;
 
 
@@ -2666,9 +2667,9 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 
 			/* CHECK FOR TOTALLY IMPENETRABLE */
 
-			if (ctype & CTYPE_IMPENETRABLE2)
+			if(ctype & CTYPE_IMPENETRABLE2)
 			{
-				if (!(gCollisionList[i].sides & SIDE_BITS_BOTTOM))	// dont do this if we landed on top of it
+				if(!(gCollisionList[i].sides & SIDE_BITS_BOTTOM))	// dont do this if we landed on top of it
 				{
 					gCoord.x = theNode->OldCoord.x;					// dont take any chances, just move back to original safe place
 					gCoord.z = theNode->OldCoord.z;
@@ -2677,11 +2678,11 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 
 			/* CHECK FOR HURT ME */
 
-			if (ctype & CTYPE_HURTME)
+			if(ctype & CTYPE_HURTME)
 			{
 				PlayerGotHit(hitObj, 0);
 
-				if (ctype & CTYPE_FLAMING)							// see if hurter was flaming
+				if(ctype & CTYPE_FLAMING)							// see if hurter was flaming
 					gPlayerInfo.burnTimer = 2.5;
 			}
 		}
@@ -2691,7 +2692,7 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 	/* CHECK & HANDLE TERRAIN  COLLISION */
 	/*************************************/
 
-	if (useBBoxForTerrain)
+	if(useBBoxForTerrain)
 		bottomOff = theNode->BBox.min.y;							// use bbox for bottom
 	else
 		bottomOff = theNode->BottomOff;								// use collision box for bottom
@@ -2700,14 +2701,14 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 
 	distToFloor = (gCoord.y + bottomOff) - terrainY;				// calc amount I'm above or under
 
-	if (distToFloor <= 0.0f)										// see if on or under floor
+	if(distToFloor <= 0.0f)										// see if on or under floor
 	{
 		gCoord.y = terrainY - bottomOff;
 		gDelta.y = -200.0f;											// keep some downward momentum
 		theNode->StatusBits |= STATUS_BIT_ONGROUND;
 		gPlayerSlipperyFactor = gTileSlipperyFactor;				// use this slippery factor
 
-		switch (gLevelNum)
+		switch(gLevelNum)
 		{
 		case	LEVEL_NUM_BLOBBOSS:								// if touch blob boss ground, then hurt player and bounce back up
 			PlayerLoseHealth(.25, PLAYER_DEATH_TYPE_EXPLODE);
@@ -2716,16 +2717,16 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 			break;
 
 		case	LEVEL_NUM_CLOUD:								// see if touch electric floor
-			if (gTileAttribFlags & (TILE_ATTRIB_ELECTROCUTE_AREA0 | TILE_ATTRIB_ELECTROCUTE_AREA1))
+			if(gTileAttribFlags & (TILE_ATTRIB_ELECTROCUTE_AREA0 | TILE_ATTRIB_ELECTROCUTE_AREA1))
 			{
-				if (gTileAttribFlags & TILE_ATTRIB_ELECTROCUTE_AREA0)	// check area #0
+				if(gTileAttribFlags & TILE_ATTRIB_ELECTROCUTE_AREA0)	// check area #0
 				{
-					if (!gBumperCarGateBlown[0])
+					if(!gBumperCarGateBlown[0])
 						PlayerTouchedElectricFloor(theNode);
 				}
 				else													// check area #1
 				{
-					if (!gBumperCarGateBlown[1])
+					if(!gBumperCarGateBlown[1])
 						PlayerTouchedElectricFloor(theNode);
 				}
 			}
@@ -2740,9 +2741,9 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 	// Only apply slopes when on the ground (or really close to it)
 	//
 
-	if ((fabs(gPlayerInfo.analogControlX) < 0.5f) && (fabs(gPlayerInfo.analogControlZ) < 0.5f))			// only do slopes if player isn't controlling
+	if((fabs(gPlayerInfo.analogControlX) < 0.5f) && (fabs(gPlayerInfo.analogControlZ) < 0.5f))			// only do slopes if player isn't controlling
 	{
-		if ((distToFloor <= 0.0f) || (gPlayerInfo.distToFloor < 15.0f))
+		if((distToFloor <= 0.0f) || (gPlayerInfo.distToFloor < 15.0f))
 		{
 			gDelta.x += gRecentTerrainNormal.x * (fps * PLAYER_SLOPE_ACCEL);
 			gDelta.z += gRecentTerrainNormal.z * (fps * PLAYER_SLOPE_ACCEL);
@@ -2753,27 +2754,27 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 	/* SEE IF IN WATER VOLUME */
 	/**************************/
 
-	if (!killed)
+	if(!killed)
 	{
 		int		patchNum;
 		Boolean	wasInWater;
 
 		/* REMEMBER IF ALREADY IN WATER */
 
-		if (theNode->StatusBits & STATUS_BIT_UNDERWATER)
+		if(theNode->StatusBits & STATUS_BIT_UNDERWATER)
 			wasInWater = true;
 		else
 			wasInWater = false;
 
 		/* CHECK IF IN WATER NOW */
 
-		if (DoWaterCollisionDetect(theNode, gCoord.x, gCoord.y + theNode->BottomOff + 50.0f, gCoord.z, &patchNum))
+		if(DoWaterCollisionDetect(theNode, gCoord.x, gCoord.y + theNode->BottomOff + 50.0f, gCoord.z, &patchNum))
 		{
 			gPlayerInfo.waterPatch = patchNum;
 
 			gCoord.y = gWaterBBox[patchNum].max.y;
 
-			switch (gWaterList[patchNum].type)
+			switch(gWaterList[patchNum].type)
 			{
 				/* JUNGLE MUD */
 
@@ -2791,7 +2792,7 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 
 				/* GOOD OLD ZAPPING H2O */
 			default:
-				if (!wasInWater)
+				if(!wasInWater)
 					PlayerEntersWater(theNode, patchNum);
 			}
 		}
@@ -2807,31 +2808,31 @@ static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrai
 // Handles fist collision with punchable objects
 //
 
-static void CheckPunchCollision(ObjNode* player)
+static void CheckPunchCollision(ObjNode *player)
 {
 	static OGLPoint3D fistOff = { 0,-12 ,0 };
 	OGLPoint3D	fistCoord;
 	int			i;
-	ObjNode* hitObj;
+	ObjNode *hitObj;
 	Boolean		endPunch;
 	float		fistSize = 30.0f * gPlayerInfo.scale;
 
 	FindCoordOnJoint(player, PLAYER_JOINT_RIGHTHAND, &fistOff, &fistCoord);			// calc coord of fist
 
-	if (DoSimpleBoxCollision(fistCoord.y + fistSize, fistCoord.y - fistSize,
+	if(DoSimpleBoxCollision(fistCoord.y + fistSize, fistCoord.y - fistSize,
 		fistCoord.x - fistSize, fistCoord.x + fistSize,
 		fistCoord.z + fistSize, fistCoord.z - fistSize,
 		CTYPE_MISC | CTYPE_ENEMY | CTYPE_TRIGGER | CTYPE_POWERUP))
 	{
-		for (i = 0; i < gNumCollisions; i++)										// affect all hit objects
+		for(i = 0; i < gNumCollisions; i++)										// affect all hit objects
 		{
 			hitObj = gCollisionList[i].objectPtr;									// get hit ObjNode
-			if (hitObj)
+			if(hitObj)
 			{
-				if (hitObj->HitByWeaponHandler[WEAPON_TYPE_FIST])					// see if there is a handler for the punch
+				if(hitObj->HitByWeaponHandler[WEAPON_TYPE_FIST])					// see if there is a handler for the punch
 				{
 					endPunch = (hitObj->HitByWeaponHandler[WEAPON_TYPE_FIST])(gPlayerInfo.rightHandObj, hitObj, &fistCoord, nil);	// call the handler
-					if (endPunch)
+					if(endPunch)
 					{
 						player->PunchCanHurt = false;
 						PlayEffect3D(EFFECT_PUNCHHIT, &fistCoord);
@@ -2853,15 +2854,15 @@ static void CheckPunchCollision(ObjNode* player)
 // INPUT:	theNode = the node of the player
 //
 
-static void CheckPlayerActionControls(ObjNode* theNode)
+static void CheckPlayerActionControls(ObjNode *theNode)
 {
 	/* SEE IF DO CHEAT */
 
-	if (GetKeyState(SDL_SCANCODE_B) &&
+	if(GetKeyState(SDL_SCANCODE_B) &&
 		GetKeyState(SDL_SCANCODE_R) &&
 		GetKeyState(SDL_SCANCODE_I))
 	{
-		if (gPlayerInfo.lives < 3)
+		if(gPlayerInfo.lives < 3)
 			gPlayerInfo.lives = 3;
 		gPlayerInfo.health = 1.0;
 		gPlayerInfo.fuel = 1.0;
@@ -2876,16 +2877,16 @@ static void CheckPlayerActionControls(ObjNode* theNode)
 	/* SEE IF JUMP */
 	/***************/
 
-	if (GetNewNeedState(kNeed_Jump))										// see if user pressed the key
+	if(GetNewNeedState(kNeed_Jump))										// see if user pressed the key
 	{
 		/* SEE IF ENTER CANNON ON CLOUD LEVEL */
 
-		if (gLevelNum == LEVEL_NUM_CLOUD)
+		if(gLevelNum == LEVEL_NUM_CLOUD)
 		{
 			float	cannonTipX, cannonTipZ;
 			gCannon = IsPlayerInPositionToEnterCannon(&cannonTipX, &cannonTipZ);		// see if in position for cannon
 
-			if (gCannon != nil)
+			if(gCannon != nil)
 			{
 				gCoord.x = cannonTipX;
 				gCoord.z = cannonTipZ;
@@ -2900,23 +2901,23 @@ static void CheckPlayerActionControls(ObjNode* theNode)
 
 		/* CHECK JUMP-JET */
 
-		if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP) ||
+		if((theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP) ||
 			(theNode->Skeleton->AnimNum == PLAYER_ANIM_FALL))			// if already jumping or falling then try Jump Jet
 		{
-			if (fabs(gDelta.y) < 800.0f)								// do it now if near apex of jump
+			if(fabs(gDelta.y) < 800.0f)								// do it now if near apex of jump
 				StartJumpJet(theNode);
 			else
-				if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)			// not @ apex, but if already jumping then tag to do JJ @ apex
+				if(theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)			// not @ apex, but if already jumping then tag to do JJ @ apex
 					gDoJumpJetAtApex = true;
 				else
-					if (gPlayerInfo.distToFloor > 200.0f)						// not @ apex, but if falling still allow JJ if high enough off ground
+					if(gPlayerInfo.distToFloor > 200.0f)						// not @ apex, but if falling still allow JJ if high enough off ground
 						StartJumpJet(theNode);
 		}
 
 		/* CHECK REGULAR JUMP */
 
 		else
-			if ((theNode->StatusBits & STATUS_BIT_ONGROUND) || (gPlayerInfo.distToFloor < 15.0f))		// must be on something solid
+			if((theNode->StatusBits & STATUS_BIT_ONGROUND) || (gPlayerInfo.distToFloor < 15.0f))		// must be on something solid
 			{
 				MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_JUMP, 5.0f);
 				PlayEffect3D(EFFECT_JUMP, &gCoord);
@@ -2925,7 +2926,7 @@ static void CheckPlayerActionControls(ObjNode* theNode)
 
 				gDelta.y += JUMP_DELTA;
 
-				if (theNode->MPlatform != nil)			// if jumping off of mplatform then also use platform's deltas
+				if(theNode->MPlatform != nil)			// if jumping off of mplatform then also use platform's deltas
 				{
 					gDelta.x += theNode->MPlatform->Delta.x;
 					gDelta.y += theNode->MPlatform->Delta.y;
@@ -2945,12 +2946,12 @@ no_jump:
 
 /******************* START JUMPJET *********************/
 
-static void StartJumpJet(ObjNode* theNode)
+static void StartJumpJet(ObjNode *theNode)
 {
-	if (!gResetJumpJet)								// cannot do this until jump jet has been reset
+	if(!gResetJumpJet)								// cannot do this until jump jet has been reset
 		return;
 
-	if (gPlayerInfo.jumpJet <= 0.0f)				// can't do it if out of jump jet fuel
+	if(gPlayerInfo.jumpJet <= 0.0f)				// can't do it if out of jump jet fuel
 	{
 		gDoJumpJetAtApex = false;
 		PlayEffect(EFFECT_NOJUMPJET);
@@ -2959,14 +2960,14 @@ static void StartJumpJet(ObjNode* theNode)
 	}
 
 	gPlayerInfo.jumpJet -= .1f;						// dec fuel
-	if (gPlayerInfo.jumpJet < 0.0f)
+	if(gPlayerInfo.jumpJet < 0.0f)
 		gPlayerInfo.jumpJet = 0.0f;
 
 	gResetJumpJet = false;
 
 	/* SET ANIM */
 
-	if (gPlayerInfo.scaleRatio > 1.0f)				// do special version of player is giant
+	if(gPlayerInfo.scaleRatio > 1.0f)				// do special version of player is giant
 	{
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_GIANTJUMPJET, 6.0f);
 		theNode->Skeleton->AnimSpeed = .6;
@@ -3004,7 +3005,7 @@ static void StartJumpJet(ObjNode* theNode)
 
 /**************** END JUMPJET *****************/
 
-static void EndJumpJet(ObjNode* theNode)
+static void EndJumpJet(ObjNode *theNode)
 {
 	DeleteSparkle(theNode->Sparkles[PLAYER_SPARKLE_LEFTFOOT]);							// delete sparkles on feet
 	theNode->Sparkles[PLAYER_SPARKLE_LEFTFOOT] = -1;
@@ -3015,7 +3016,7 @@ static void EndJumpJet(ObjNode* theNode)
 
 /****************** UPDATE JUMP JET PARTICLES ********************/
 
-static void UpdateJumpJetParticles(ObjNode* theNode)
+static void UpdateJumpJetParticles(ObjNode *theNode)
 {
 	float	fps = gFramesPerSecondFrac;
 	int		particleGroup, magicNum;
@@ -3041,14 +3042,14 @@ static void UpdateJumpJetParticles(ObjNode* theNode)
 	/*********************/
 
 	gPlayerInfo.jjParticleTimer[0] -= fps;											// see if add particles
-	if (gPlayerInfo.jjParticleTimer[0] <= 0.0f)
+	if(gPlayerInfo.jjParticleTimer[0] <= 0.0f)
 	{
 		gPlayerInfo.jjParticleTimer[0] += .03f;									// reset timer
 
 		particleGroup = gPlayerInfo.jjParticleGroup[0];
 		magicNum = gPlayerInfo.jjParticleMagic[0];
 
-		if ((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
+		if((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
 		{
 			gPlayerInfo.jjParticleMagic[0] = magicNum = MyRandomLong();			// generate a random magic num
 
@@ -3066,9 +3067,9 @@ static void UpdateJumpJetParticles(ObjNode* theNode)
 			gPlayerInfo.jjParticleGroup[0] = particleGroup = NewParticleGroup(&groupDef);
 		}
 
-		if (particleGroup != -1)
+		if(particleGroup != -1)
 		{
-			for (i = 0; i < 7; i++)
+			for(i = 0; i < 7; i++)
 			{
 				p.x = x + RandomFloat2() * 30.0f;
 				p.y = y + RandomFloat2() * 30.0f;
@@ -3085,7 +3086,7 @@ static void UpdateJumpJetParticles(ObjNode* theNode)
 				newParticleDef.rotZ = 0;
 				newParticleDef.rotDZ = 0;
 				newParticleDef.alpha = 1.0;
-				if (AddParticleToGroup(&newParticleDef))
+				if(AddParticleToGroup(&newParticleDef))
 				{
 					gPlayerInfo.jjParticleGroup[0] = -1;
 					break;
@@ -3100,14 +3101,14 @@ static void UpdateJumpJetParticles(ObjNode* theNode)
 	/**************/
 
 	gPlayerInfo.jjParticleTimer[1] -= fps;											// see if add particles
-	if (gPlayerInfo.jjParticleTimer[1] <= 0.0f)
+	if(gPlayerInfo.jjParticleTimer[1] <= 0.0f)
 	{
 		gPlayerInfo.jjParticleTimer[1] += .05f;									// reset timer
 
 		particleGroup = gPlayerInfo.jjParticleGroup[1];
 		magicNum = gPlayerInfo.jjParticleMagic[1];
 
-		if ((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
+		if((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
 		{
 			gPlayerInfo.jjParticleMagic[1] = magicNum = MyRandomLong();			// generate a random magic num
 
@@ -3125,9 +3126,9 @@ static void UpdateJumpJetParticles(ObjNode* theNode)
 			gPlayerInfo.jjParticleGroup[1] = particleGroup = NewParticleGroup(&groupDef);
 		}
 
-		if (particleGroup != -1)
+		if(particleGroup != -1)
 		{
-			for (i = 0; i < 8; i++)
+			for(i = 0; i < 8; i++)
 			{
 				p.x = x + RandomFloat2() * 40.0f;
 				p.y = y + RandomFloat2() * 40.0f;
@@ -3144,7 +3145,7 @@ static void UpdateJumpJetParticles(ObjNode* theNode)
 				newParticleDef.rotZ = RandomFloat() * PI2;
 				newParticleDef.rotDZ = RandomFloat2();
 				newParticleDef.alpha = .4f + RandomFloat() * .3f;
-				if (AddParticleToGroup(&newParticleDef))
+				if(AddParticleToGroup(&newParticleDef))
 				{
 					gPlayerInfo.jjParticleGroup[1] = -1;
 					break;
@@ -3160,9 +3161,9 @@ static void UpdateJumpJetParticles(ObjNode* theNode)
 
 /*********************** SET PLAYER WALK ANIM *******************************/
 
-void SetPlayerWalkAnim(ObjNode* theNode)
+void SetPlayerWalkAnim(ObjNode *theNode)
 {
-	if (gPlayerInfo.holdingGun)
+	if(gPlayerInfo.holdingGun)
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALKWITHGUN, 9);
 	else
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALK, 9);
@@ -3171,9 +3172,9 @@ void SetPlayerWalkAnim(ObjNode* theNode)
 
 /********************* IS PLAYER DOING WALK ANIM *********************/
 
-static Boolean IsPlayerDoingWalkAnim(ObjNode* theNode)
+static Boolean IsPlayerDoingWalkAnim(ObjNode *theNode)
 {
-	if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_WALK) ||
+	if((theNode->Skeleton->AnimNum == PLAYER_ANIM_WALK) ||
 		(theNode->Skeleton->AnimNum == PLAYER_ANIM_WALKWITHGUN))
 	{
 		return(true);
@@ -3185,9 +3186,9 @@ static Boolean IsPlayerDoingWalkAnim(ObjNode* theNode)
 
 /*********************** SET PLAYER STAND ANIM *******************************/
 
-void SetPlayerStandAnim(ObjNode* theNode, float speed)
+void SetPlayerStandAnim(ObjNode *theNode, float speed)
 {
-	if (gPlayerInfo.holdingGun)
+	if(gPlayerInfo.holdingGun)
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STANDWITHGUN, speed);
 	else
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STAND, speed);
@@ -3196,9 +3197,9 @@ void SetPlayerStandAnim(ObjNode* theNode, float speed)
 
 /********************* IS PLAYER DOING STAND ANIM *********************/
 
-static Boolean IsPlayerDoingStandAnim(ObjNode* theNode)
+static Boolean IsPlayerDoingStandAnim(ObjNode *theNode)
 {
-	if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_STAND) ||
+	if((theNode->Skeleton->AnimNum == PLAYER_ANIM_STAND) ||
 		(theNode->Skeleton->AnimNum == PLAYER_ANIM_STANDWITHGUN))
 	{
 		return(true);
@@ -3225,10 +3226,10 @@ void StartWeaponChangeAnim(void)
 
 /**************** DO PLAYER MAGNET SKIING ****************************/
 
-static void DoPlayerMagnetSkiing(ObjNode* player)
+static void DoPlayerMagnetSkiing(ObjNode *player)
 {
 	short		magnetMonsterID;
-	ObjNode* magMonster;
+	ObjNode *magMonster;
 	float		distToTarget, mx, mz, tx, tz, y;
 	OGLVector2D	v;
 	float		fps = gFramesPerSecondFrac;
@@ -3276,7 +3277,7 @@ static void DoPlayerMagnetSkiing(ObjNode* player)
 	tz = mz + v.y * TARGET_SKIING_DIST;
 
 	distToTarget = CalcDistance(gCoord.x, gCoord.z, tx, tz);							// calc dist to target point
-	if (distToTarget > 2000.0f)								// limit it
+	if(distToTarget > 2000.0f)								// limit it
 		distToTarget = 2000.0f;
 
 
@@ -3299,18 +3300,18 @@ static void DoPlayerMagnetSkiing(ObjNode* player)
 
 	/* SEE IF HIT WATER */
 
-	if (GetWaterY(gCoord.x, gCoord.z, &y))					// get water y
+	if(GetWaterY(gCoord.x, gCoord.z, &y))					// get water y
 	{
 		float	playerBottomY = gCoord.y + player->BBox.min.y + 10.0f;
 		float	diff;
 
 		diff = y - playerBottomY;
 
-		if (diff >= 0.0f)								// see if hit water
+		if(diff >= 0.0f)								// see if hit water
 		{
 			gDelta.y += 7000.0f * fps;					// thrust up
 
-			if (diff > 30.0f)							// see if too far under
+			if(diff > 30.0f)							// see if too far under
 				gCoord.y += diff - 30.0f;				// adjust back up
 
 			gCoord.y += gDelta.y * fps;
@@ -3322,20 +3323,20 @@ static void DoPlayerMagnetSkiing(ObjNode* player)
 	/* SEE IF HIT GROUND */
 
 	y = GetTerrainY(gCoord.x, gCoord.z);					// get terrain y
-	if ((gCoord.y + player->BBox.min.y) <= y)				// see if hit ground
+	if((gCoord.y + player->BBox.min.y) <= y)				// see if hit ground
 	{
 		gCoord.y = y - player->BBox.min.y;
 
-		if (gDelta.y < 0.0f)
+		if(gDelta.y < 0.0f)
 			gDelta.y *= -.5f;
 	}
 
 
 	/* SEE IF HIT SOLID OBJECT HARD */
 
-	if (HandleCollisions(player, CTYPE_MISC, -.6) || DoFenceCollision(player))
+	if(HandleCollisions(player, CTYPE_MISC, -.6) || DoFenceCollision(player))
 	{
-		if (player->Speed2D > 500.0f)											// see if hit hard
+		if(player->Speed2D > 500.0f)											// see if hit hard
 		{
 			EndMagnetSkiing(player, true);										// end skiing
 		}
@@ -3345,9 +3346,9 @@ static void DoPlayerMagnetSkiing(ObjNode* player)
 	/* SEE IF ABORT SKIING */
 	/***********************/
 
-	if (gTargetPickup != nil)															// see if already aborted via collision
+	if(gTargetPickup != nil)															// see if already aborted via collision
 	{
-		if (GetNewNeedState(kNeed_Jump)
+		if(GetNewNeedState(kNeed_Jump)
 			|| GetNewNeedState(kNeed_Shoot)
 			|| GetNewNeedState(kNeed_PunchPickup))
 		{
@@ -3362,12 +3363,12 @@ static void DoPlayerMagnetSkiing(ObjNode* player)
 
 /******************** END MAGNET SKIING **************************/
 
-static void EndMagnetSkiing(ObjNode* player, Boolean crash)
+static void EndMagnetSkiing(ObjNode *player, Boolean crash)
 {
 	short		magnetMonsterID;
-	ObjNode* magMonster;
+	ObjNode *magMonster;
 
-	if (gTargetPickup == nil)					// this can get called twice, so check if pickup==nil
+	if(gTargetPickup == nil)					// this can get called twice, so check if pickup==nil
 		return;
 
 	/* GET INFO ABOUT THE MAGNET MONSTER */
@@ -3382,7 +3383,7 @@ static void EndMagnetSkiing(ObjNode* player, Boolean crash)
 	gTargetPickup->Delta.y = 300.0f;
 	gTargetPickup->Delta.z = gDelta.z * .8f;
 
-	if (crash)
+	if(crash)
 	{
 		KillPlayer(PLAYER_DEATH_TYPE_EXPLODE);
 	}
@@ -3391,7 +3392,6 @@ static void EndMagnetSkiing(ObjNode* player, Boolean crash)
 
 	gTargetPickup = nil;										// no longer a target
 }
-
 
 
 

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -1926,8 +1926,10 @@ static void UpdatePlayerAutoAim(ObjNode* player)
 	tx = gPlayerInfo.autoAimTargetX;									// get targt aim coords
 	tz = gPlayerInfo.autoAimTargetZ;
 
-	TurnObjectTowardTarget(player, &gCoord, tx, tz, PI2, false);
-
+	// TurnObjectTowardTarget(player, &gCoord, tx, tz, PI2, false);
+	// Disable for fpv, causes locking of camera movement. Gonna have to aim manually buddy
+	// Note: This only disables the player facing towards enemy, bullets still go sideways
+	// fordcars/OttoMatic-VR#8
 }
 
 #pragma mark -

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -15,60 +15,60 @@
 /*    PROTOTYPES            */
 /****************************/
 
-static void MovePlayerRobot_JumpJet(ObjNode *theNode);
-static void MovePlayerRobot_Jump(ObjNode *theNode);
-static void MovePlayerRobot_Punch(ObjNode *theNode);
-static void MovePlayerRobot_PickupAndDeposit(ObjNode *theNode);
-static void MovePlayerRobot_PickupAndHoldGun(ObjNode *theNode);
-static void MovePlayerRobot_Drink(ObjNode *theNode);
-static void MovePlayerRobot_RideZip(ObjNode *theNode);
-static void MovePlayerRobot_ClimbInto(ObjNode *theNode);
-static void MovePlayerRobot_ShotFromCannon(ObjNode *theNode);
-static void MovePlayerRobot_BumperCar(ObjNode *theNode);
-static void MovePlayerRobot_GrabbedByStrongMan(ObjNode *theNode);
-static void MovePlayerRobot_RocketSled(ObjNode *theNode);
-static void MovePlayerRobot_Fall_BottomlessPit(ObjNode *theNode);
-static void MovePlayerRobot_Drilled(ObjNode *theNode);
+static void MovePlayerRobot_JumpJet(ObjNode* theNode);
+static void MovePlayerRobot_Jump(ObjNode* theNode);
+static void MovePlayerRobot_Punch(ObjNode* theNode);
+static void MovePlayerRobot_PickupAndDeposit(ObjNode* theNode);
+static void MovePlayerRobot_PickupAndHoldGun(ObjNode* theNode);
+static void MovePlayerRobot_Drink(ObjNode* theNode);
+static void MovePlayerRobot_RideZip(ObjNode* theNode);
+static void MovePlayerRobot_ClimbInto(ObjNode* theNode);
+static void MovePlayerRobot_ShotFromCannon(ObjNode* theNode);
+static void MovePlayerRobot_BumperCar(ObjNode* theNode);
+static void MovePlayerRobot_GrabbedByStrongMan(ObjNode* theNode);
+static void MovePlayerRobot_RocketSled(ObjNode* theNode);
+static void MovePlayerRobot_Fall_BottomlessPit(ObjNode* theNode);
+static void MovePlayerRobot_Drilled(ObjNode* theNode);
 
-static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrain);
-static void CheckPunchCollision(ObjNode *player);
-static void CheckPlayerActionControls(ObjNode *theNode);
-static void DoRobotFrictionAndGravity(ObjNode *theNode, float friction);
-static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Boolean useBBoxForTerrain);
-static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode);
-static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode);
-static void MovePlayerRobot_Stand(ObjNode *theNode);
-static void MovePlayerRobot_Walk(ObjNode *theNode);
-static void MovePlayerRobot_Fall(ObjNode *theNode);
-static void MovePlayerRobot_Grabbed(ObjNode *theNode);
-static void MovePlayerRobot_Flattened(ObjNode *theNode);
-static void MovePlayerRobot_Charging(ObjNode *theNode);
-static void MovePlayerRobot_Zapped(ObjNode *theNode);
-static void MovePlayerRobot_Drowned(ObjNode *theNode);
-static void MovePlayerRobot_Thrown(ObjNode *theNode);
-static void MovePlayerRobot_GotHit(ObjNode *theNode);
-static void MovePlayerRobot_Accordian(ObjNode *theNode);
-static void MovePlayerRobot_ChangeWeapon(ObjNode *theNode);
-static void MovePlayerRobot_Bubble(ObjNode *theNode);
-static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode *theNode);
-static void MovePlayerRobot_SuckedIntoWell(ObjNode *theNode);
-static void MovePlayerRobot_RideZip(ObjNode *theNode);
-static void MovePlayerRobot_Throw(ObjNode *theNode);
-static void MovePlayerRobot_BellySlide(ObjNode *theNode);
+static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrain);
+static void CheckPunchCollision(ObjNode* player);
+static void CheckPlayerActionControls(ObjNode* theNode);
+static void DoRobotFrictionAndGravity(ObjNode* theNode, float friction);
+static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Boolean useBBoxForTerrain);
+static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode);
+static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode);
+static void MovePlayerRobot_Stand(ObjNode* theNode);
+static void MovePlayerRobot_Walk(ObjNode* theNode);
+static void MovePlayerRobot_Fall(ObjNode* theNode);
+static void MovePlayerRobot_Grabbed(ObjNode* theNode);
+static void MovePlayerRobot_Flattened(ObjNode* theNode);
+static void MovePlayerRobot_Charging(ObjNode* theNode);
+static void MovePlayerRobot_Zapped(ObjNode* theNode);
+static void MovePlayerRobot_Drowned(ObjNode* theNode);
+static void MovePlayerRobot_Thrown(ObjNode* theNode);
+static void MovePlayerRobot_GotHit(ObjNode* theNode);
+static void MovePlayerRobot_Accordian(ObjNode* theNode);
+static void MovePlayerRobot_ChangeWeapon(ObjNode* theNode);
+static void MovePlayerRobot_Bubble(ObjNode* theNode);
+static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode* theNode);
+static void MovePlayerRobot_SuckedIntoWell(ObjNode* theNode);
+static void MovePlayerRobot_RideZip(ObjNode* theNode);
+static void MovePlayerRobot_Throw(ObjNode* theNode);
+static void MovePlayerRobot_BellySlide(ObjNode* theNode);
 
-static float CalcWalkAnimSpeed(ObjNode *theNode);
-static void StartJumpJet(ObjNode *theNode);
-static void EndJumpJet(ObjNode *theNode);
-static void UpdateJumpJetParticles(ObjNode *theNode);
-static void UpdatePlayerAutoAim(ObjNode *player);
+static float CalcWalkAnimSpeed(ObjNode* theNode);
+static void StartJumpJet(ObjNode* theNode);
+static void EndJumpJet(ObjNode* theNode);
+static void UpdateJumpJetParticles(ObjNode* theNode);
+static void UpdatePlayerAutoAim(ObjNode* player);
 
-static Boolean IsPlayerDoingWalkAnim(ObjNode *theNode);
-static Boolean IsPlayerDoingStandAnim(ObjNode *theNode);
+static Boolean IsPlayerDoingWalkAnim(ObjNode* theNode);
+static Boolean IsPlayerDoingStandAnim(ObjNode* theNode);
 
-static void TurnPlayerTowardPunchable(ObjNode *player);
+static void TurnPlayerTowardPunchable(ObjNode* player);
 
-static void DoPlayerMagnetSkiing(ObjNode *player);
-static void EndMagnetSkiing(ObjNode *player, Boolean crash);
+static void DoPlayerMagnetSkiing(ObjNode* player);
+static void EndMagnetSkiing(ObjNode* player, Boolean crash);
 static void VerifyTargetPickup(void);
 
 
@@ -90,11 +90,11 @@ static void VerifyTargetPickup(void);
 
 #define DEBUG_PLAYER_VAPOR		0
 #if DEBUG_PLAYER_VAPOR
-	#define PLAYER_VAPOR_THRESHOLD	10.0f
-	#define PLAYER_VAPOR_ALPHA		1.0f
+#define PLAYER_VAPOR_THRESHOLD	10.0f
+#define PLAYER_VAPOR_ALPHA		1.0f
 #else
-	#define	PLAYER_VAPOR_THRESHOLD	700.0f
-	#define PLAYER_VAPOR_ALPHA		0.2f
+#define	PLAYER_VAPOR_THRESHOLD	700.0f
+#define PLAYER_VAPOR_ALPHA		0.2f
 #endif
 
 #define	JUMP_DELTA					1800.0f
@@ -137,8 +137,8 @@ u_short			gPlayerTileAttribs;
 
 OGLVector3D		gPreCollisionDelta;
 
-ObjNode 		*gTargetPickup = nil;
-ObjNode			*gCannon = nil;
+ObjNode* gTargetPickup = nil;
+ObjNode* gCannon = nil;
 
 float			gPlayerBottomOff = 0;
 
@@ -171,45 +171,45 @@ float	gCurrentMaxSpeed = PLAYER_NORMAL_MAX_SPEED;
 //			rotY = rotation to assign to player if oldObj is nil.
 //
 
-void InitPlayer_Robot(OGLPoint3D *where, float rotY)
+void InitPlayer_Robot(OGLPoint3D* where, float rotY)
 {
-ObjNode	*newObj;
-float	y;
-int		i;
+	ObjNode* newObj;
+	float	y;
+	int		i;
 
-		/* FIND THE Y COORD TO START */
+	/* FIND THE Y COORD TO START */
 
-	y = FindHighestCollisionAtXZ(where->x,where->z, CTYPE_MISC|CTYPE_TERRAIN);
+	y = FindHighestCollisionAtXZ(where->x, where->z, CTYPE_MISC | CTYPE_TERRAIN);
 
 	if (gLevelNum == LEVEL_NUM_BLOBBOSS)
 		y += 5000.0f;				// blob boss, player falls from above
 	else
-		y += -gObjectGroupBBoxList[MODEL_GROUP_SKELETONBASE+SKELETON_TYPE_OTTO][0].min.y * PLAYER_DEFAULT_SCALE + 5.0f;	// offset y so foot is on ground
+		y += -gObjectGroupBBoxList[MODEL_GROUP_SKELETONBASE + SKELETON_TYPE_OTTO][0].min.y * PLAYER_DEFAULT_SCALE + 5.0f;	// offset y so foot is on ground
 
 
 		/*****************************/
 		/* MAKE OTTO'S SKELETON BODY */
 		/*****************************/
 
-	gNewObjectDefinition.type 		= SKELETON_TYPE_OTTO;
-	gNewObjectDefinition.animNum	= 0;
-	gNewObjectDefinition.coord.x 	= where->x;
-	gNewObjectDefinition.coord.z 	= where->z;
-	gNewObjectDefinition.coord.y 	= y;
-	gNewObjectDefinition.flags 		= STATUS_BIT_NOFOG|STATUS_BIT_DONTCULL;
-	gNewObjectDefinition.slot 		= PLAYER_SLOT;
-	gNewObjectDefinition.moveCall	= MovePlayer_Robot;
-	gNewObjectDefinition.rot 		= 0;
-	gNewObjectDefinition.scale 		= PLAYER_DEFAULT_SCALE;
+	gNewObjectDefinition.type = SKELETON_TYPE_OTTO;
+	gNewObjectDefinition.animNum = 0;
+	gNewObjectDefinition.coord.x = where->x;
+	gNewObjectDefinition.coord.z = where->z;
+	gNewObjectDefinition.coord.y = y;
+	gNewObjectDefinition.flags = STATUS_BIT_NOFOG | STATUS_BIT_DONTCULL;
+	gNewObjectDefinition.slot = PLAYER_SLOT;
+	gNewObjectDefinition.moveCall = MovePlayer_Robot;
+	gNewObjectDefinition.rot = 0;
+	gNewObjectDefinition.scale = PLAYER_DEFAULT_SCALE;
 
 	newObj = MakeNewSkeletonObject(&gNewObjectDefinition);
 
-	gPlayerInfo.objNode 	= newObj;
+	gPlayerInfo.objNode = newObj;
 
 	newObj->Rot.y = rotY;
 
 
-				/* SET COLLISION INFO */
+	/* SET COLLISION INFO */
 
 	newObj->BoundingSphereRadius *= 2.0f;
 
@@ -219,46 +219,46 @@ int		i;
 	SetObjectCollisionBounds(newObj, newObj->BBox.max.y, gPlayerBottomOff = newObj->BBox.min.y, -40, 40, 40, -40);
 
 
-		/***********************/
-		/* CREATE HAND OBJECTS */
-		/***********************/
+	/***********************/
+	/* CREATE HAND OBJECTS */
+	/***********************/
 
-	for (i = 0; i < (GLOBAL_ObjType_FlameGunHand-GLOBAL_ObjType_OttoLeftHand+1); i++)
+	for (i = 0; i < (GLOBAL_ObjType_FlameGunHand - GLOBAL_ObjType_OttoLeftHand + 1); i++)
 	{
-		BG3D_SphereMapGeomteryMaterial(MODEL_GROUP_GLOBAL, GLOBAL_ObjType_OttoLeftHand+i, 0, MULTI_TEXTURE_COMBINE_ADD, SPHEREMAP_SObjType_DarkDusk);	// set this model to be sphere mapped
+		BG3D_SphereMapGeomteryMaterial(MODEL_GROUP_GLOBAL, GLOBAL_ObjType_OttoLeftHand + i, 0, MULTI_TEXTURE_COMBINE_ADD, SPHEREMAP_SObjType_DarkDusk);	// set this model to be sphere mapped
 	}
 
 
-			/* LEFT HAND */
+	/* LEFT HAND */
 
-	gNewObjectDefinition.group 		= MODEL_GROUP_GLOBAL;
-	gNewObjectDefinition.type 		= GLOBAL_ObjType_OttoLeftHand;
-	gNewObjectDefinition.slot		= SLOT_OF_DUMB;
-	gNewObjectDefinition.moveCall 	= nil;
-	gPlayerInfo.leftHandObj 		= MakeNewDisplayGroupObject(&gNewObjectDefinition);
+	gNewObjectDefinition.group = MODEL_GROUP_GLOBAL;
+	gNewObjectDefinition.type = GLOBAL_ObjType_OttoLeftHand;
+	gNewObjectDefinition.slot = SLOT_OF_DUMB;
+	gNewObjectDefinition.moveCall = nil;
+	gPlayerInfo.leftHandObj = MakeNewDisplayGroupObject(&gNewObjectDefinition);
 
 
 
-			/* RIGHT HAND */
+	/* RIGHT HAND */
 
-	gNewObjectDefinition.type 	= GLOBAL_ObjType_OttoRightHand;
-	gPlayerInfo.rightHandObj 	= MakeNewDisplayGroupObject(&gNewObjectDefinition);
+	gNewObjectDefinition.type = GLOBAL_ObjType_OttoRightHand;
+	gPlayerInfo.rightHandObj = MakeNewDisplayGroupObject(&gNewObjectDefinition);
 
 	gPlayerInfo.rightHandObj->Kind = WEAPON_TYPE_FIST;			// set weapon type since this gets passed to weapon handlers
 
 	gPlayerInfo.rightHandObj->Damage = PUNCH_DAMAGE;
 
 
-		/*******************/
-		/* SET OTHER STUFF */
-		/*******************/
+	/*******************/
+	/* SET OTHER STUFF */
+	/*******************/
 
 	gTargetMaxSpeed = PLAYER_NORMAL_MAX_SPEED;
 	gCurrentMaxSpeed = PLAYER_NORMAL_MAX_SPEED;
 
 
 
-	AttachShadowToObject(newObj, 0, DEFAULT_PLAYER_SHADOW_SCALE,DEFAULT_PLAYER_SHADOW_SCALE * .8f, true);
+	AttachShadowToObject(newObj, 0, DEFAULT_PLAYER_SHADOW_SCALE, DEFAULT_PLAYER_SHADOW_SCALE * .8f, true);
 
 	CreatePlayerSparkles(newObj);
 
@@ -275,9 +275,9 @@ int		i;
 
 /******************** MOVE PLAYER: ROBOT ***********************/
 
-void MovePlayer_Robot(ObjNode *theNode)
+void MovePlayer_Robot(ObjNode* theNode)
 {
-	static void(*myMoveTable[])(ObjNode *) =
+	static void(*myMoveTable[])(ObjNode*) =
 	{
 		MovePlayerRobot_Stand,							// standing
 		MovePlayerRobot_Walk,							// walking
@@ -324,17 +324,17 @@ void MovePlayer_Robot(ObjNode *theNode)
 		gTimeSinceLastShoot += gFramesPerSecondFrac;
 	}
 
-			/* FIRST SEE IF NEED TO UPDATE GROWTH */
+	/* FIRST SEE IF NEED TO UPDATE GROWTH */
 
 	UpdatePlayerGrowth(theNode);
 
 
-			/* JUMP TO HANDLER */
+	/* JUMP TO HANDLER */
 
 	myMoveTable[theNode->Skeleton->AnimNum](theNode);
 
 
-		/* SEE IF SHOULD FREEZE CAMERA */
+	/* SEE IF SHOULD FREEZE CAMERA */
 
 	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMPJET)		// dont move camera from during jump-jet
 		gFreezeCameraFromXZ = true;
@@ -346,7 +346,7 @@ void MovePlayer_Robot(ObjNode *theNode)
 
 /******************** MOVE PLAYER ROBOT: STAND ***********************/
 
-static void MovePlayerRobot_Stand(ObjNode *theNode)
+static void MovePlayerRobot_Stand(ObjNode* theNode)
 {
 	theNode->Rot.x = 0;								// make sure this is correct
 	theNode->Rot.z = 0;								// make sure this is correct
@@ -359,27 +359,27 @@ static void MovePlayerRobot_Stand(ObjNode *theNode)
 		goto update;
 
 
-			/* SEE IF SHOULD WALK */
+	/* SEE IF SHOULD WALK */
 
 	if (IsPlayerDoingStandAnim(theNode))
 	{
-		float	animSpeed =  CalcWalkAnimSpeed(theNode);
+		float	animSpeed = CalcWalkAnimSpeed(theNode);
 
 		if ((animSpeed > WALK_STAND_THRESHOLD) && (gTimeSinceLastThrust < THRUST_TIMER))
 			SetPlayerWalkAnim(theNode);
 	}
 
-			/* DO CONTROL */
-			//
-			// do this last since we want any jump command to work smoothly
-			//
+	/* DO CONTROL */
+	//
+	// do this last since we want any jump command to work smoothly
+	//
 
 	CheckPlayerActionControls(theNode);
 
 
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -388,7 +388,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: WALK ***********************/
 
-static void MovePlayerRobot_Walk(ObjNode *theNode)
+static void MovePlayerRobot_Walk(ObjNode* theNode)
 {
 	theNode->Rot.x = 0;								// make sure this is correct
 	theNode->Rot.z = 0;								// make sure this is correct
@@ -398,12 +398,12 @@ static void MovePlayerRobot_Walk(ObjNode *theNode)
 	CheckPlayerActionControls(theNode);
 
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	UpdatePlayerAutoAim(theNode);
 
 	if ((gPlayerInfo.analogControlX == 0.0f) &&			// if no user control, do heavy friction
-		 (gPlayerInfo.analogControlZ == 0.0f))
+		(gPlayerInfo.analogControlZ == 0.0f))
 	{
 		DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
 	}
@@ -416,11 +416,11 @@ static void MovePlayerRobot_Walk(ObjNode *theNode)
 		goto update;
 
 
-			/* SEE IF SHOULD STAND */
+	/* SEE IF SHOULD STAND */
 
 	if (IsPlayerDoingWalkAnim(theNode))
 	{
-		float	animSpeed =  CalcWalkAnimSpeed(theNode);
+		float	animSpeed = CalcWalkAnimSpeed(theNode);
 
 		if ((animSpeed < WALK_STAND_THRESHOLD) || (gTimeSinceLastThrust > THRUST_TIMER))
 			SetPlayerStandAnim(theNode, 8);
@@ -430,7 +430,7 @@ static void MovePlayerRobot_Walk(ObjNode *theNode)
 
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -438,9 +438,9 @@ update:
 
 /******************* CALC WALK ANIM SPEED **********************/
 
-static float CalcWalkAnimSpeed(ObjNode *theNode)
+static float CalcWalkAnimSpeed(ObjNode* theNode)
 {
-float	animSpeed,accSpeed;
+	float	animSpeed, accSpeed;
 
 	accSpeed = sqrt(theNode->AccelVector.x * theNode->AccelVector.x + theNode->AccelVector.y * theNode->AccelVector.y);		// calc dist of accel vector
 	accSpeed *= 1000.0f;
@@ -463,16 +463,16 @@ float	animSpeed,accSpeed;
 
 /******************** MOVE PLAYER ROBOT: JUMP ***********************/
 
-static void MovePlayerRobot_Jump(ObjNode *theNode)
+static void MovePlayerRobot_Jump(ObjNode* theNode)
 {
-Byte	aimMode;
+	Byte	aimMode;
 
-			/* DO CONTROL */
+	/* DO CONTROL */
 
 	CheckPlayerActionControls(theNode);
 
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	if (gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
 		aimMode = AIM_MODE_NONE;
@@ -486,26 +486,26 @@ Byte	aimMode;
 
 	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)		// only bother if still in Fall anim
 	{
-				/* SEE IF LANDED */
+		/* SEE IF LANDED */
 
 		if (theNode->StatusBits & STATUS_BIT_ONGROUND)
 		{
 			SetPlayerStandAnim(theNode, 8);
 		}
 
-				/* SEE IF FALLING */
+		/* SEE IF FALLING */
 		else
-		if (gDelta.y < 0.0f)
-		{
-			if (gDoJumpJetAtApex)							// see if we wanted to jet @ the apex
-				StartJumpJet(theNode);
-			else
-				MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);
-		}
+			if (gDelta.y < 0.0f)
+			{
+				if (gDoJumpJetAtApex)							// see if we wanted to jet @ the apex
+					StartJumpJet(theNode);
+				else
+					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);
+			}
 	}
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -513,15 +513,15 @@ update:
 
 /******************** MOVE PLAYER ROBOT: PICKUP AND DEPOSIT ***********************/
 
-static void MovePlayerRobot_PickupAndDeposit(ObjNode *theNode)
+static void MovePlayerRobot_PickupAndDeposit(ObjNode* theNode)
 {
-OGLMatrix4x4	m,m2;
+	OGLMatrix4x4	m, m2;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
 	VerifyTargetPickup();
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
@@ -529,15 +529,15 @@ OGLMatrix4x4	m,m2;
 		goto update;
 
 
-			/* KEEP AIMED AT TARGET */
+	/* KEEP AIMED AT TARGET */
 
 	if (gTargetPickup && (!theNode->IsHoldingPickup))
 	{
 		TurnObjectTowardTarget(theNode, &gCoord, gTargetPickup->Coord.x,
-								gTargetPickup->Coord.z, 9.0, false);
+			gTargetPickup->Coord.z, 9.0, false);
 	}
 
-			/* SEE IF DONE */
+	/* SEE IF DONE */
 
 	if (theNode->Skeleton->AnimHasStopped)										// go to stand when done with anim
 		SetPlayerStandAnim(theNode, 2);
@@ -576,29 +576,29 @@ OGLMatrix4x4	m,m2;
 	}
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
 
 
 
-		/*********************/
-		/* UPDATE THE PICKUP */
-		/*********************/
+	/*********************/
+	/* UPDATE THE PICKUP */
+	/*********************/
 
 	if (gTargetPickup && theNode->IsHoldingPickup)
 	{
 		gTargetPickup->MoveCall = nil;										// make sure the pickup no longer has control if itself
 
-		OGLMatrix4x4_SetTranslate(&m,0,-20,0);								// set offset to palm of hand
+		OGLMatrix4x4_SetTranslate(&m, 0, -20, 0);								// set offset to palm of hand
 		m.value[M00] = gTargetPickup->Scale.x;								// insert scale values
 		m.value[M11] = gTargetPickup->Scale.y;
 		m.value[M22] = gTargetPickup->Scale.z;
 
 		FindJointFullMatrix(theNode, PLAYER_JOINT_RIGHTHAND, &m2);
 		OGLMatrix4x4_Multiply(&m, &m2, &m2);
-		OGLMatrix4x4_SetScale(&m, 1.0f/theNode->Scale.x,1.0f/theNode->Scale.x,1.0f/theNode->Scale.x);	// cancel out the player's scale thats in that matrix
+		OGLMatrix4x4_SetScale(&m, 1.0f / theNode->Scale.x, 1.0f / theNode->Scale.x, 1.0f / theNode->Scale.x);	// cancel out the player's scale thats in that matrix
 		OGLMatrix4x4_Multiply(&m, &m2, &gTargetPickup->BaseTransformMatrix);
 
 		SetObjectTransformMatrix(gTargetPickup);
@@ -612,7 +612,7 @@ update:
 // For picking up holdable objects when left hand is currently empty - item goes into hand instead of being deposited.
 //
 
-static void MovePlayerRobot_PickupAndHoldGun(ObjNode *theNode)
+static void MovePlayerRobot_PickupAndHoldGun(ObjNode* theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -621,10 +621,10 @@ static void MovePlayerRobot_PickupAndHoldGun(ObjNode *theNode)
 	if (gTargetPickup)														// if not holding it yet, then keep aimed at it
 	{
 		TurnObjectTowardTarget(theNode, &gCoord, gTargetPickup->Coord.x,
-								gTargetPickup->Coord.z, 9.0, false);
+			gTargetPickup->Coord.z, 9.0, false);
 	}
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
@@ -632,13 +632,13 @@ static void MovePlayerRobot_PickupAndHoldGun(ObjNode *theNode)
 		goto update;
 
 
-			/* SEE IF DONE */
+	/* SEE IF DONE */
 
 	if (theNode->Skeleton->AnimHasStopped)
 		SetPlayerStandAnim(theNode, 4);
 
 
-			/* SEE IF GRAB IT NOW */
+	/* SEE IF GRAB IT NOW */
 
 	if (gTargetPickup)
 	{
@@ -662,7 +662,7 @@ static void MovePlayerRobot_PickupAndHoldGun(ObjNode *theNode)
 		}
 	}
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -673,27 +673,27 @@ update:
 // Does both the pickup and holding of the magnet
 //
 
-static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode *theNode)
+static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode* theNode)
 {
 	VerifyTargetPickup();
 
 
-			/****************************/
-			/* MOVE DURING HOLDING PART */
-			/****************************/
+	/****************************/
+	/* MOVE DURING HOLDING PART */
+	/****************************/
 
 	if (theNode->IsHoldingPickup)
 	{
 		DoPlayerMagnetSkiing(theNode);
 	}
 
-			/***************************/
-			/* MOVE DURING PICKUP PART */
-			/***************************/
+	/***************************/
+	/* MOVE DURING PICKUP PART */
+	/***************************/
 	else
 	{
 
-				/* MOVE PLAYER */
+		/* MOVE PLAYER */
 
 		gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 		DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
@@ -701,16 +701,16 @@ static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode *theNode)
 			goto update;
 
 
-				/* KEEP AIMED AT TARGET */
+		/* KEEP AIMED AT TARGET */
 
 		if (gTargetPickup && (!theNode->IsHoldingPickup))
 		{
 			TurnObjectTowardTarget(theNode, &gCoord, gTargetPickup->Coord.x,
-									gTargetPickup->Coord.z, 9.0, false);
+				gTargetPickup->Coord.z, 9.0, false);
 		}
 	}
 
-			/* SEE IF DONE */
+	/* SEE IF DONE */
 
 	if (theNode->Skeleton->AnimNum != PLAYER_ANIM_PICKUPANDHOLDMAGNET)			// if anim has changed then finish things up with the pickup
 	{
@@ -718,21 +718,21 @@ static void MovePlayerRobot_PickupAndHoldMagnet(ObjNode *theNode)
 	}
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
 
 
 
-		/*********************/
-		/* UPDATE THE MAGNET */
-		/*********************/
+	/*********************/
+	/* UPDATE THE MAGNET */
+	/*********************/
 
 	if (gTargetPickup && theNode->IsHoldingPickup)
 	{
-		static const OGLPoint3D	off = {0,0,10};
-		OGLPoint3D	p1,p2;
+		static const OGLPoint3D	off = { 0,0,10 };
+		OGLPoint3D	p1, p2;
 
 		gTargetPickup->MoveCall = nil;										// make sure the pickup no longer has control if itself
 		gTargetPickup->CType = 0;											// no collision during this
@@ -746,14 +746,14 @@ update:
 		gTargetPickup->Coord.z = (p1.z + p2.z) * .5f;
 
 		gTargetPickup->Rot.y = theNode->Rot.y;								// match y rot to player
-		gTargetPickup->Rot.x = -PI/2;										// flip to aim forward
+		gTargetPickup->Rot.x = -PI / 2;										// flip to aim forward
 
 					/* UPDATE NODE */
 
 		UpdateObjectTransforms(gTargetPickup);
 		UpdateShadow(gTargetPickup);
 
-		DisplayHelpMessage(HELP_MESSAGE_LETGOMAGNET,1.0, true);
+		DisplayHelpMessage(HELP_MESSAGE_LETGOMAGNET, 1.0, true);
 	}
 }
 
@@ -775,7 +775,7 @@ static void VerifyTargetPickup(void)
 
 /******************** MOVE PLAYER ROBOT: CHANGE WEAPON ***********************/
 
-static void MovePlayerRobot_ChangeWeapon(ObjNode *theNode)
+static void MovePlayerRobot_ChangeWeapon(ObjNode* theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -787,7 +787,7 @@ static void MovePlayerRobot_ChangeWeapon(ObjNode *theNode)
 		goto update;
 
 
-			/* SEE IF DONE */
+	/* SEE IF DONE */
 
 	if (theNode->Skeleton->AnimHasStopped)
 	{
@@ -795,11 +795,11 @@ static void MovePlayerRobot_ChangeWeapon(ObjNode *theNode)
 	}
 
 
-			/* FAST WEAPON SWITCHING */
-			//
-			// Player can keep cycling weapons until Otto has started
-			// pulling out a new gun (ChangeWeapon anim flag)
-			//
+	/* FAST WEAPON SWITCHING */
+	//
+	// Player can keep cycling weapons until Otto has started
+	// pulling out a new gun (ChangeWeapon anim flag)
+	//
 
 	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON
 		&& !theNode->ChangeWeapon)
@@ -807,7 +807,7 @@ static void MovePlayerRobot_ChangeWeapon(ObjNode *theNode)
 		CheckWeaponChangeControls(theNode);
 	}
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -815,7 +815,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: SUCKED INTO WELL ***********************/
 
-static void MovePlayerRobot_SuckedIntoWell(ObjNode *theNode)
+static void MovePlayerRobot_SuckedIntoWell(ObjNode* theNode)
 {
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
@@ -840,10 +840,10 @@ static void MovePlayerRobot_SuckedIntoWell(ObjNode *theNode)
 
 /******************** MOVE PLAYER ROBOT: PUNCH ***********************/
 
-static void MovePlayerRobot_Punch(ObjNode *theNode)
+static void MovePlayerRobot_Punch(ObjNode* theNode)
 {
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	TurnPlayerTowardPunchable(theNode);										// aim at punchable
 
@@ -852,7 +852,7 @@ static void MovePlayerRobot_Punch(ObjNode *theNode)
 	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
-			/* SEE IF CHECK FOR PUNCH COLLISION */
+	/* SEE IF CHECK FOR PUNCH COLLISION */
 
 	if (theNode->PunchCanHurt)
 	{
@@ -861,7 +861,7 @@ static void MovePlayerRobot_Punch(ObjNode *theNode)
 	}
 
 
-			/* SEE IF SHOULD STAND */
+	/* SEE IF SHOULD STAND */
 
 	if (theNode->Skeleton->AnimHasStopped)
 	{
@@ -869,7 +869,7 @@ static void MovePlayerRobot_Punch(ObjNode *theNode)
 	}
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -878,17 +878,17 @@ update:
 
 /******************** MOVE PLAYER ROBOT: THROW ***********************/
 
-static void MovePlayerRobot_Throw(ObjNode *theNode)
+static void MovePlayerRobot_Throw(ObjNode* theNode)
 {
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
 	if (DoPlayerMovementAndCollision(theNode, AIM_MODE_NONE, false))
 		goto update;
 
-			/* SEE IF CHECK FOR RELEASE DART */
+	/* SEE IF CHECK FOR RELEASE DART */
 
 	if (theNode->ThrowDartNow)
 	{
@@ -897,7 +897,7 @@ static void MovePlayerRobot_Throw(ObjNode *theNode)
 	}
 
 
-			/* SEE IF SHOULD STAND */
+	/* SEE IF SHOULD STAND */
 
 	if (theNode->Skeleton->AnimHasStopped)
 	{
@@ -905,7 +905,7 @@ static void MovePlayerRobot_Throw(ObjNode *theNode)
 	}
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -915,10 +915,10 @@ update:
 
 /*********************** TURN PLAYER TOWARD PUNCHABLE ****************************/
 
-static void TurnPlayerTowardPunchable(ObjNode *player)
+static void TurnPlayerTowardPunchable(ObjNode* player)
 {
-ObjNode *thisNode,*nearest;
-float	ex,ey,ez,dist,bestDist,maxDist;
+	ObjNode* thisNode, * nearest;
+	float	ex, ey, ez, dist, bestDist, maxDist;
 
 	bestDist = 10000000;
 	nearest = nil;
@@ -945,17 +945,17 @@ float	ex,ey,ez,dist,bestDist,maxDist;
 			nearest = thisNode;
 		}
 
-next:
+	next:
 		thisNode = thisNode->NextNode;							// next target node
-	}while(thisNode != nil);
+	} while (thisNode != nil);
 
 
-			/* THERE IS SOMETHING THERE */
+	/* THERE IS SOMETHING THERE */
 
 	if (nearest)
 	{
 		TurnObjectTowardTarget(player, &gCoord, nearest->Coord.x,
-								nearest->Coord.z, 6.0, false);
+			nearest->Coord.z, 6.0, false);
 	}
 
 
@@ -964,32 +964,32 @@ next:
 
 /******************** MOVE PLAYER ROBOT: JUMPJET ***********************/
 
-static void MovePlayerRobot_JumpJet(ObjNode *theNode)
+static void MovePlayerRobot_JumpJet(ObjNode* theNode)
 {
 
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	if (DoPlayerMovementAndCollision_JumpJet(theNode))
 		goto update;
 
 
-			/* SEE IF LANDED */
+	/* SEE IF LANDED */
 
 	if (theNode->StatusBits & STATUS_BIT_ONGROUND)
 	{
 		SetPlayerStandAnim(theNode, 7);
 	}
-			/* SEE IF DONE WITH JUMP-JET ANIM */
+	/* SEE IF DONE WITH JUMP-JET ANIM */
 	else
-	if (theNode->Skeleton->AnimHasStopped || GetNewNeedState(kNeed_Jump))
-	{
-		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);		// make fall anim
-	}
+		if (theNode->Skeleton->AnimHasStopped || GetNewNeedState(kNeed_Jump))
+		{
+			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_FALL, 4.0);		// make fall anim
+		}
 
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 
@@ -1008,10 +1008,10 @@ update:
 
 /******************** MOVE PLAYER ROBOT: FALL ***********************/
 
-static void MovePlayerRobot_Fall(ObjNode *theNode)
+static void MovePlayerRobot_Fall(ObjNode* theNode)
 {
-float	oldDY = gDelta.y;
-Byte	aimMode;
+	float	oldDY = gDelta.y;
+	Byte	aimMode;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1025,12 +1025,12 @@ Byte	aimMode;
 		return;
 	}
 
-				/* DO CONTROL */
+	/* DO CONTROL */
 
 	CheckPlayerActionControls(theNode);
 
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	if (gTimeSinceLastThrust > .5f)			// only aim player if he's under user control
 		aimMode = AIM_MODE_NONE;
@@ -1042,24 +1042,24 @@ Byte	aimMode;
 		goto update;
 
 
-			/*****************/
-			/* SEE IF LANDED */
-			/*****************/
+	/*****************/
+	/* SEE IF LANDED */
+	/*****************/
 
 	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_FALL)						// only bother if still in Fall anim
 	{
 		if ((theNode->StatusBits & STATUS_BIT_ONGROUND) || (gPlayerInfo.distToFloor < 10.0f))
 		{
 
-					/* DO ANIM AFTER LANDED */
+			/* DO ANIM AFTER LANDED */
 
-			switch(theNode->Skeleton->AnimNum)
+			switch (theNode->Skeleton->AnimNum)
 			{
-				case	PLAYER_ANIM_BUMPERCAR:								// check if trigger put us in bumper car
-						break;
+			case	PLAYER_ANIM_BUMPERCAR:								// check if trigger put us in bumper car
+				break;
 
-				default:
-						SetPlayerStandAnim(theNode, 8);						// default to standing when landing
+			default:
+				SetPlayerStandAnim(theNode, 8);						// default to standing when landing
 			}
 
 			if (oldDY < -300.0f)											// if landing fast enough
@@ -1074,18 +1074,18 @@ Byte	aimMode;
 					{
 						DeformationType		defData;
 
-						defData.type 				= DEFORMATION_TYPE_RADIALWAVE;
-						defData.amplitude 			= oldDY * -.08f * gPlayerInfo.scaleRatio;
+						defData.type = DEFORMATION_TYPE_RADIALWAVE;
+						defData.amplitude = oldDY * -.08f * gPlayerInfo.scaleRatio;
 						if (defData.amplitude > 1000.0f)
 							defData.amplitude = 1000.0f;
 
-						defData.radius 				= 0;
-						defData.speed 				= 4000;
-						defData.origin.x			= gCoord.x;
-						defData.origin.y			= gCoord.z;
-						defData.oneOverWaveLength 	= 1.0f / (400.0f * gPlayerInfo.scaleRatio);
-						defData.radialWidth			= 600.0f;
-						defData.decayRate			= 200.0f * gPlayerInfo.scaleRatio;
+						defData.radius = 0;
+						defData.speed = 4000;
+						defData.origin.x = gCoord.x;
+						defData.origin.y = gCoord.z;
+						defData.oneOverWaveLength = 1.0f / (400.0f * gPlayerInfo.scaleRatio);
+						defData.radialWidth = 600.0f;
+						defData.decayRate = 200.0f * gPlayerInfo.scaleRatio;
 						NewSuperTileDeformation(&defData);
 					}
 				}
@@ -1094,7 +1094,7 @@ Byte	aimMode;
 	}
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -1103,14 +1103,14 @@ update:
 
 /******************** MOVE PLAYER ROBOT: FALL BOTTOMLESS PIT ***********************/
 
-static void MovePlayerRobot_Fall_BottomlessPit(ObjNode *theNode)
+static void MovePlayerRobot_Fall_BottomlessPit(ObjNode* theNode)
 {
-float	fps = gFramesPerSecondFrac;
+	float	fps = gFramesPerSecondFrac;
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;
 	gDelta.x = gDelta.z = 0;
 
-			/* SEE IF TIME FOR DEATH EXIT TRANSITION */
+	/* SEE IF TIME FOR DEATH EXIT TRANSITION */
 
 	if (gDeathTimer > 0.0f)
 	{
@@ -1119,7 +1119,7 @@ float	fps = gFramesPerSecondFrac;
 			StartDeathExit(0);
 	}
 
-			/* DO MOVEMENT */
+	/* DO MOVEMENT */
 
 	DoRobotFrictionAndGravity(theNode, PLAYER_AIR_FRICTION);
 	gCoord.x += gDelta.x * fps;
@@ -1136,9 +1136,9 @@ float	fps = gFramesPerSecondFrac;
 // no control and we don't care about a lot of things in the collision.
 //
 
-static void MovePlayerRobot_Thrown(ObjNode *theNode)
+static void MovePlayerRobot_Thrown(ObjNode* theNode)
 {
-float	fps = gFramesPerSecondFrac;
+	float	fps = gFramesPerSecondFrac;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1153,9 +1153,9 @@ float	fps = gFramesPerSecondFrac;
 	theNode->Rot.x += fps * 10.0f;
 
 
-			/* COLLISION */
+	/* COLLISION */
 
-	HandleCollisions(theNode, CTYPE_MISC|CTYPE_TERRAIN|CTYPE_FENCE, -.6);
+	HandleCollisions(theNode, CTYPE_MISC | CTYPE_TERRAIN | CTYPE_FENCE, -.6);
 	if (theNode->StatusBits & STATUS_BIT_ONGROUND)								// once on ground then stop
 	{
 		theNode->Rot.x = 0;
@@ -1169,14 +1169,14 @@ float	fps = gFramesPerSecondFrac;
 
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 	UpdatePlayer_Robot(theNode);
 }
 
 /******************** MOVE PLAYER ROBOT: GRABBED ***********************/
 
-static void MovePlayerRobot_Grabbed(ObjNode *theNode)
+static void MovePlayerRobot_Grabbed(ObjNode* theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1187,7 +1187,7 @@ static void MovePlayerRobot_Grabbed(ObjNode *theNode)
 
 /******************** MOVE PLAYER ROBOT: GRABBED BY STRONGMAN ***********************/
 
-static void MovePlayerRobot_GrabbedByStrongMan(ObjNode *theNode)
+static void MovePlayerRobot_GrabbedByStrongMan(ObjNode* theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1198,7 +1198,7 @@ static void MovePlayerRobot_GrabbedByStrongMan(ObjNode *theNode)
 
 /******************** MOVE PLAYER ROBOT: DRILLED ***********************/
 
-static void MovePlayerRobot_Drilled(ObjNode *theNode)
+static void MovePlayerRobot_Drilled(ObjNode* theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1213,7 +1213,7 @@ static void MovePlayerRobot_Drilled(ObjNode *theNode)
 // when in H20
 //
 
-static void MovePlayerRobot_Zapped(ObjNode *theNode)
+static void MovePlayerRobot_Zapped(ObjNode* theNode)
 {
 	if (gLevelNum == LEVEL_NUM_BLOBBOSS)				// if blob boss then must have fallen into water/ground to bob
 		gCoord.y = GetTerrainY(gCoord.x, gCoord.z);
@@ -1221,7 +1221,7 @@ static void MovePlayerRobot_Zapped(ObjNode *theNode)
 	theNode->ZappedTimer -= gFramesPerSecondFrac;					// dec timer
 	if (theNode->ZappedTimer <= 0.0f)
 	{
-			/* KILL THE PLAYER */
+		/* KILL THE PLAYER */
 
 		if (gExplodePlayerAfterElectrocute)
 			KillPlayer(PLAYER_DEATH_TYPE_EXPLODE);
@@ -1235,7 +1235,7 @@ static void MovePlayerRobot_Zapped(ObjNode *theNode)
 
 /******************** MOVE PLAYER ROBOT: DROWNED ***********************/
 
-static void MovePlayerRobot_Drowned(ObjNode *theNode)
+static void MovePlayerRobot_Drowned(ObjNode* theNode)
 {
 	if (gPlayerInfo.waterPatch == -1)						// see if have patch, otherwise use terrain y
 		gCoord.y = GetTerrainY(gCoord.x, gCoord.z);
@@ -1243,7 +1243,7 @@ static void MovePlayerRobot_Drowned(ObjNode *theNode)
 		gCoord.y = gWaterBBox[gPlayerInfo.waterPatch].max.y;
 
 
-			/* SEE IF END */
+	/* SEE IF END */
 
 	if (gDeathTimer > 0.0f)
 	{
@@ -1260,9 +1260,9 @@ static void MovePlayerRobot_Drowned(ObjNode *theNode)
 
 /******************** MOVE PLAYER ROBOT: FLATTENED ***********************/
 
-static void MovePlayerRobot_Flattened(ObjNode *theNode)
+static void MovePlayerRobot_Flattened(ObjNode* theNode)
 {
-u_long	wasOnGround = theNode->StatusBits & STATUS_BIT_ONGROUND;
+	u_long	wasOnGround = theNode->StatusBits & STATUS_BIT_ONGROUND;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1274,12 +1274,12 @@ u_long	wasOnGround = theNode->StatusBits & STATUS_BIT_ONGROUND;
 		goto update;
 
 
-			/* PLAY BOUNCE SFX */
+	/* PLAY BOUNCE SFX */
 
 	if ((theNode->StatusBits & STATUS_BIT_ONGROUND) && (!wasOnGround))
 	{
-//		if (gDelta.y > 20.0f)
-			PlayEffect3D(EFFECT_PLAYERCLANG, &gCoord);
+		//		if (gDelta.y > 20.0f)
+		PlayEffect3D(EFFECT_PLAYERCLANG, &gCoord);
 	}
 
 
@@ -1298,11 +1298,11 @@ update:
 
 /******************** MOVE PLAYER ROBOT: BELLY SLIDE ***********************/
 
-static void MovePlayerRobot_BellySlide(ObjNode *theNode)
+static void MovePlayerRobot_BellySlide(ObjNode* theNode)
 {
 	theNode->Rot.x = theNode->Rot.z = 0;
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_DEFAULT_FRICTION);
@@ -1325,7 +1325,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: CHARGING ***********************/
 
-static void MovePlayerRobot_Charging(ObjNode *theNode)
+static void MovePlayerRobot_Charging(ObjNode* theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1337,7 +1337,7 @@ static void MovePlayerRobot_Charging(ObjNode *theNode)
 		goto update;
 
 
-			/* SEE IF DISCHARGE SUPERNOVA */
+	/* SEE IF DISCHARGE SUPERNOVA */
 
 	if (gPlayerInfo.superNovaStatic)						// if this obj exists then we're still charging
 	{
@@ -1347,7 +1347,7 @@ static void MovePlayerRobot_Charging(ObjNode *theNode)
 		}
 	}
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -1355,9 +1355,9 @@ update:
 
 /******************** MOVE PLAYER ROBOT: GOT HIT ***********************/
 
-static void MovePlayerRobot_GotHit(ObjNode *theNode)
+static void MovePlayerRobot_GotHit(ObjNode* theNode)
 {
-float	f;
+	float	f;
 
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1374,7 +1374,7 @@ float	f;
 		goto update;
 
 
-			/* SEE IF DONE */
+	/* SEE IF DONE */
 
 	if (theNode->Skeleton->AnimHasStopped)
 	{
@@ -1383,7 +1383,7 @@ float	f;
 	}
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -1392,7 +1392,7 @@ update:
 
 /******************** MOVE PLAYER ROBOT: ACCORDIAN ***********************/
 
-static void MovePlayerRobot_Accordian(ObjNode *theNode)
+static void MovePlayerRobot_Accordian(ObjNode* theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1401,7 +1401,7 @@ static void MovePlayerRobot_Accordian(ObjNode *theNode)
 	gCoord.y = GetTerrainY(gCoord.x, gCoord.z) + theNode->BBox.min.y;
 
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	DoRobotFrictionAndGravity(theNode, PLAYER_HEAVY_FRICTION);
@@ -1409,7 +1409,7 @@ static void MovePlayerRobot_Accordian(ObjNode *theNode)
 		goto update;
 
 
-			/* SEE IF DONE */
+	/* SEE IF DONE */
 
 	theNode->AccordianTimer -= gFramesPerSecondFrac;
 	if (theNode->AccordianTimer <= 0.0f)
@@ -1419,7 +1419,7 @@ static void MovePlayerRobot_Accordian(ObjNode *theNode)
 	}
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 update:
 	UpdatePlayer_Robot(theNode);
@@ -1428,11 +1428,11 @@ update:
 
 /******************** MOVE PLAYER ROBOT: BUBBLE ***********************/
 
-static void MovePlayerRobot_Bubble(ObjNode *theNode)
+static void MovePlayerRobot_Bubble(ObjNode* theNode)
 {
-float	y;
+	float	y;
 
-			/* KEEP FLOATING ABOVE GROUND */
+	/* KEEP FLOATING ABOVE GROUND */
 
 	y = GetTerrainY(gCoord.x, gCoord.z) + 300.0f;
 	gDelta.y = y - gCoord.y;
@@ -1445,12 +1445,12 @@ float	y;
 	DoPlayerMovementAndCollision_Bubble(theNode);
 
 
-			/* UPDATE ME */
+	/* UPDATE ME */
 
 	UpdatePlayer_Robot(theNode);
 
 
-		/* UPDATE BUBBLE */
+	/* UPDATE BUBBLE */
 
 	if (gSoapBubble)
 	{
@@ -1463,7 +1463,7 @@ float	y;
 
 /******************** MOVE PLAYER ROBOT: DRINK ***********************/
 
-static void MovePlayerRobot_Drink(ObjNode *theNode)
+static void MovePlayerRobot_Drink(ObjNode* theNode)
 {
 	gTimeSinceLastThrust = 0;							// reset this so camera won't auto-adjust during this anim (a bit of a hack really)
 
@@ -1475,7 +1475,7 @@ static void MovePlayerRobot_Drink(ObjNode *theNode)
 		goto update;
 
 
-			/* SEE IF DONE */
+	/* SEE IF DONE */
 
 	if (theNode->Skeleton->AnimHasStopped)
 	{
@@ -1492,9 +1492,9 @@ update:
 
 /******************** MOVE PLAYER ROBOT: RIDE ZIP ***********************/
 
-static void MovePlayerRobot_RideZip(ObjNode *theNode)
+static void MovePlayerRobot_RideZip(ObjNode* theNode)
 {
-float	r = theNode->Rot.y;
+	float	r = theNode->Rot.y;
 
 
 	gCoord = gCurrentZip->Coord;		// get pully coord
@@ -1510,11 +1510,11 @@ float	r = theNode->Rot.y;
 
 /******************** MOVE PLAYER ROBOT: CLIMB INTO ***********************/
 
-static void MovePlayerRobot_ClimbInto(ObjNode *theNode)
+static void MovePlayerRobot_ClimbInto(ObjNode* theNode)
 {
 	theNode->Skeleton->AnimSpeed = 1.6;
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	gPlayerInfo.analogControlX = gPlayerInfo.analogControlZ = 0;			// no user control during this anim
 	gDelta.x = gDelta.y = gDelta.z = 0.0f;
@@ -1530,11 +1530,11 @@ update:
 
 /******************** MOVE PLAYER ROBOT: SHOT FROM CANNON ***********************/
 
-static void MovePlayerRobot_ShotFromCannon(ObjNode *theNode)
+static void MovePlayerRobot_ShotFromCannon(ObjNode* theNode)
 {
-float	fps = gFramesPerSecondFrac;
+	float	fps = gFramesPerSecondFrac;
 
-			/* MOVE PLAYER */
+	/* MOVE PLAYER */
 
 	gDelta.y -= 500.0f * fps;
 
@@ -1542,9 +1542,9 @@ float	fps = gFramesPerSecondFrac;
 	gCoord.y += gDelta.y * fps;
 	gCoord.z += gDelta.z * fps;
 
-	theNode->Rot.x -= PI/7 * fps;
+	theNode->Rot.x -= PI / 7 * fps;
 
-			/* SEE IF HIT GROUND */
+	/* SEE IF HIT GROUND */
 
 	if ((gCoord.y + theNode->BBox.min.y) <= GetTerrainY(gCoord.x, gCoord.z))
 	{
@@ -1555,7 +1555,7 @@ float	fps = gFramesPerSecondFrac;
 
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 	UpdatePlayer_Robot(theNode);
 }
@@ -1564,11 +1564,11 @@ float	fps = gFramesPerSecondFrac;
 
 /******************** MOVE PLAYER ROBOT: BUMPER CAR ***********************/
 
-static void MovePlayerRobot_BumperCar(ObjNode *theNode)
+static void MovePlayerRobot_BumperCar(ObjNode* theNode)
 {
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 	AlignPlayerInBumperCar(theNode);
 	UpdatePlayer_Robot(theNode);
@@ -1576,11 +1576,11 @@ static void MovePlayerRobot_BumperCar(ObjNode *theNode)
 
 /******************** MOVE PLAYER ROBOT: ROCKETSLED ***********************/
 
-static void MovePlayerRobot_RocketSled(ObjNode *theNode)
+static void MovePlayerRobot_RocketSled(ObjNode* theNode)
 {
 
 
-			/* UPDATE IT */
+	/* UPDATE IT */
 
 	AlignPlayerInRocketSled(theNode);
 	UpdatePlayer_Robot(theNode);
@@ -1592,11 +1592,11 @@ static void MovePlayerRobot_RocketSled(ObjNode *theNode)
 
 /************************ UPDATE PLAYER: ROBOT ***************************/
 
-void UpdatePlayer_Robot(ObjNode *theNode)
+void UpdatePlayer_Robot(ObjNode* theNode)
 {
-float fps = gFramesPerSecondFrac;
+	float fps = gFramesPerSecondFrac;
 
-			/* VERIFY BOTTOMLESS PIT */
+	/* VERIFY BOTTOMLESS PIT */
 
 	if (gLevelNum == LEVEL_NUM_CLOUD)
 	{
@@ -1608,62 +1608,62 @@ float fps = gFramesPerSecondFrac;
 	}
 
 
-		/* VERIFY ANIM INFO */
+	/* VERIFY ANIM INFO */
 
-	switch(theNode->Skeleton->AnimNum)
+	switch (theNode->Skeleton->AnimNum)
 	{
-		case	PLAYER_ANIM_STANDWITHGUN:
-				if (!gPlayerInfo.holdingGun)											// verify using correct stand anim
-					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STAND, 6.0);
-				break;
+	case	PLAYER_ANIM_STANDWITHGUN:
+		if (!gPlayerInfo.holdingGun)											// verify using correct stand anim
+			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STAND, 6.0);
+		break;
 
-		case	PLAYER_ANIM_STAND:
-				if (gPlayerInfo.holdingGun)
-					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STANDWITHGUN, 6.0);
-				break;
+	case	PLAYER_ANIM_STAND:
+		if (gPlayerInfo.holdingGun)
+			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STANDWITHGUN, 6.0);
+		break;
 
-		case	PLAYER_ANIM_WALKWITHGUN:
-				if (!gPlayerInfo.holdingGun)											// verify using correct walk anim
-					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALK, 9.0);
-				break;
+	case	PLAYER_ANIM_WALKWITHGUN:
+		if (!gPlayerInfo.holdingGun)											// verify using correct walk anim
+			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALK, 9.0);
+		break;
 
-		case	PLAYER_ANIM_WALK:
-				if (gPlayerInfo.holdingGun)
-					MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALKWITHGUN, 9.0);
-				break;
+	case	PLAYER_ANIM_WALK:
+		if (gPlayerInfo.holdingGun)
+			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALKWITHGUN, 9.0);
+		break;
 
 	}
 
 
-		/* UPDATE SPECIAL COLLISION INFO */
+	/* UPDATE SPECIAL COLLISION INFO */
 
-	switch(theNode->Skeleton->AnimNum)
+	switch (theNode->Skeleton->AnimNum)
 	{
-		case	PLAYER_ANIM_ACCORDIAN:
-		case	PLAYER_ANIM_FLATTENED:
-		case	PLAYER_ANIM_DROWNED:
-		case	PLAYER_ANIM_GOTHIT:
-				theNode->TopOff = theNode->BBox.max.y * .7f;
-				break;
+	case	PLAYER_ANIM_ACCORDIAN:
+	case	PLAYER_ANIM_FLATTENED:
+	case	PLAYER_ANIM_DROWNED:
+	case	PLAYER_ANIM_GOTHIT:
+		theNode->TopOff = theNode->BBox.max.y * .7f;
+		break;
 
-		default:
-				theNode->TopOff = gObjectGroupBBoxList[MODEL_GROUP_SKELETONBASE+SKELETON_TYPE_OTTO][0].max.y * theNode->Scale.y * .7f;
-				break;
+	default:
+		theNode->TopOff = gObjectGroupBBoxList[MODEL_GROUP_SKELETONBASE + SKELETON_TYPE_OTTO][0].max.y * theNode->Scale.y * .7f;
+		break;
 	}
 
 
-		/* UPDATE OBJECT AS LONG AS NOT BEING MATRIX CONTROLLED */
+	/* UPDATE OBJECT AS LONG AS NOT BEING MATRIX CONTROLLED */
 
-	switch(theNode->Skeleton->AnimNum)
+	switch (theNode->Skeleton->AnimNum)
 	{
-		case	PLAYER_ANIM_GRABBED:
-		case	PLAYER_ANIM_GRABBED2:
-		case	PLAYER_ANIM_GRABBEDBYSTRONGMAN:
-		case	PLAYER_ANIM_ROCKETSLED:
-				break;
+	case	PLAYER_ANIM_GRABBED:
+	case	PLAYER_ANIM_GRABBED2:
+	case	PLAYER_ANIM_GRABBEDBYSTRONGMAN:
+	case	PLAYER_ANIM_ROCKETSLED:
+		break;
 
-		default:
-				UpdateObject(theNode);
+	default:
+		UpdateObject(theNode);
 	}
 
 	gPlayerInfo.coord = gCoord;				// update player coord
@@ -1677,35 +1677,35 @@ float fps = gFramesPerSecondFrac;
 	if (theNode->Speed2D < gTargetMaxSpeed)					// if we're less than the target, then just reset current to target
 		gCurrentMaxSpeed = gTargetMaxSpeed;
 	else
-	if (gCurrentMaxSpeed > gTargetMaxSpeed)					// see if in overdrive, so readjust currnet
-	{
-		if (theNode->Speed2D < gCurrentMaxSpeed)			// we're slower than Current, so adjust current down to us
+		if (gCurrentMaxSpeed > gTargetMaxSpeed)					// see if in overdrive, so readjust currnet
 		{
-			gCurrentMaxSpeed = theNode->Speed2D;
+			if (theNode->Speed2D < gCurrentMaxSpeed)			// we're slower than Current, so adjust current down to us
+			{
+				gCurrentMaxSpeed = theNode->Speed2D;
+			}
 		}
-	}
 
-			/* UPDATE SPARKLES & FLAME */
+	/* UPDATE SPARKLES & FLAME */
 
 	UpdatePlayerSparkles(theNode);
 
 	if (gPlayerInfo.burnTimer > 0.0f)
 	{
 		gPlayerInfo.burnTimer -= fps;
-		BurnSkeleton(theNode,40.0f * gPlayerInfo.scaleRatio);
+		BurnSkeleton(theNode, 40.0f * gPlayerInfo.scaleRatio);
 	}
 
 
 
 
-			/****************/
-			/* UPDATE HANDS */
-			/****************/
+	/****************/
+	/* UPDATE HANDS */
+	/****************/
 
 	UpdateRobotHands(theNode);
 
 
-			/* CHECK FOR ACCIDENTAL SUPERNOVA DISCHARGE */
+	/* CHECK FOR ACCIDENTAL SUPERNOVA DISCHARGE */
 
 	if ((theNode->Skeleton->AnimNum != PLAYER_ANIM_CHARGING) &&		// if we are not charging but we have a static object
 		(gPlayerInfo.superNovaStatic != nil))
@@ -1714,7 +1714,7 @@ float fps = gFramesPerSecondFrac;
 	}
 
 
-		/* CHECK INV TIMER */
+	/* CHECK INV TIMER */
 
 	gPlayerInfo.invincibilityTimer -= fps;
 
@@ -1726,15 +1726,15 @@ float fps = gFramesPerSecondFrac;
 
 /********************* UPDATE ROBOT HANDS *************************/
 
-void UpdateRobotHands(ObjNode *theNode)
+void UpdateRobotHands(ObjNode* theNode)
 {
-ObjNode	*lhand,*rhand;
-Boolean	holdingGun;
-int		weaponType;
+	ObjNode* lhand, * rhand;
+	Boolean	holdingGun;
+	int		weaponType;
 
-		/****************************/
-		/* DETERMINE IF HOLDING GUN */
-		/****************************/
+	/****************************/
+	/* DETERMINE IF HOLDING GUN */
+	/****************************/
 
 	if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_CHANGEWEAPON) && (!theNode->ChangeWeapon))	// see if still holding old gun during weapon change
 	{
@@ -1752,12 +1752,12 @@ int		weaponType;
 	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_BUMPERCAR)		// don't show gun while driving bumper car
 		holdingGun = false;
 	else
-	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_BUBBLE)			// don't show gun while riding bubble
-		holdingGun = false;
+		if (theNode->Skeleton->AnimNum == PLAYER_ANIM_BUBBLE)			// don't show gun while riding bubble
+			holdingGun = false;
 
-			/*****************************/
-			/* UPDATE GEOMETRY FOR HANDS */
-			/*****************************/
+	/*****************************/
+	/* UPDATE GEOMETRY FOR HANDS */
+	/*****************************/
 
 	lhand = gPlayerInfo.leftHandObj;						// get hand objects
 	rhand = gPlayerInfo.rightHandObj;
@@ -1767,55 +1767,55 @@ int		weaponType;
 	if (rhand && lhand)										// only update if both hands are legit
 	{
 
-		switch(theNode->Skeleton->AnimNum)
+		switch (theNode->Skeleton->AnimNum)
 		{
-					/* OPEN HANDS */
+			/* OPEN HANDS */
 
-			case	PLAYER_ANIM_STAND:
-			case	PLAYER_ANIM_STANDWITHGUN:
-			case	PLAYER_ANIM_JUMP:
-			case	PLAYER_ANIM_FALL:
-			case	PLAYER_ANIM_BUBBLE:
-			case	PLAYER_ANIM_SITONLEDGE:
-			case	PLAYER_ANIM_DRILLED:
-					if (rhand->Type != GLOBAL_ObjType_OttoRightHand)
-					{
-						rhand->Type = GLOBAL_ObjType_OttoRightHand;
-						ResetDisplayGroupObject(rhand);
-					}
+		case	PLAYER_ANIM_STAND:
+		case	PLAYER_ANIM_STANDWITHGUN:
+		case	PLAYER_ANIM_JUMP:
+		case	PLAYER_ANIM_FALL:
+		case	PLAYER_ANIM_BUBBLE:
+		case	PLAYER_ANIM_SITONLEDGE:
+		case	PLAYER_ANIM_DRILLED:
+			if (rhand->Type != GLOBAL_ObjType_OttoRightHand)
+			{
+				rhand->Type = GLOBAL_ObjType_OttoRightHand;
+				ResetDisplayGroupObject(rhand);
+			}
 
-					if (!holdingGun)
-					{
-						if (lhand->Type != GLOBAL_ObjType_OttoLeftHand)
-						{
-							lhand->Type = GLOBAL_ObjType_OttoLeftHand;
-							ResetDisplayGroupObject(lhand);
-						}
-					}
-					break;
+			if (!holdingGun)
+			{
+				if (lhand->Type != GLOBAL_ObjType_OttoLeftHand)
+				{
+					lhand->Type = GLOBAL_ObjType_OttoLeftHand;
+					ResetDisplayGroupObject(lhand);
+				}
+			}
+			break;
 
 
-					/* FISTS */
+			/* FISTS */
 
-			default:
-					if (rhand->Type != GLOBAL_ObjType_OttoRightFist)
-					{
-						rhand->Type = GLOBAL_ObjType_OttoRightFist;
-						ResetDisplayGroupObject(rhand);
-					}
+		default:
+			if (rhand->Type != GLOBAL_ObjType_OttoRightFist)
+			{
+				rhand->Type = GLOBAL_ObjType_OttoRightFist;
+				ResetDisplayGroupObject(rhand);
+			}
 
-					if (!holdingGun)
-					{
-						if (lhand->Type != GLOBAL_ObjType_OttoLeftFist)
-						{
-							lhand->Type = GLOBAL_ObjType_OttoLeftFist;
-							ResetDisplayGroupObject(lhand);
-						}
-					}
-					break;
+			if (!holdingGun)
+			{
+				if (lhand->Type != GLOBAL_ObjType_OttoLeftFist)
+				{
+					lhand->Type = GLOBAL_ObjType_OttoLeftFist;
+					ResetDisplayGroupObject(lhand);
+				}
+			}
+			break;
 		}
 
-				/* GUN IN LEFT HAND */
+		/* GUN IN LEFT HAND */
 
 		if (holdingGun)
 		{
@@ -1827,7 +1827,7 @@ int		weaponType;
 		}
 
 
-			/* UPDATE HAND MATRICES */
+		/* UPDATE HAND MATRICES */
 
 		FindJointFullMatrix(theNode, PLAYER_JOINT_LEFTHAND, &lhand->BaseTransformMatrix);
 		SetObjectTransformMatrix(lhand);
@@ -1852,32 +1852,32 @@ int		weaponType;
 //
 
 
-void UpdatePlayerMotionBlur(ObjNode *theNode)
+void UpdatePlayerMotionBlur(ObjNode* theNode)
 {
-int		v,i;
-static OGLColorRGBA color	= { 0.6f, 0.6f, 1.0f, PLAYER_VAPOR_ALPHA };
-static OGLColorRGBA color2	= { 0.4f, 1.0f, 0.4f, PLAYER_VAPOR_ALPHA };
-OGLPoint3D	p;
-OGLVector3D	playerVec,viewVec;
-float		dot;
+	int		v, i;
+	static OGLColorRGBA color = { 0.6f, 0.6f, 1.0f, PLAYER_VAPOR_ALPHA };
+	static OGLColorRGBA color2 = { 0.4f, 1.0f, 0.4f, PLAYER_VAPOR_ALPHA };
+	OGLPoint3D	p;
+	OGLVector3D	playerVec, viewVec;
+	float		dot;
 
 
-			/*************************/
-			/* SEE IF SHOULD TO BLUR */
-			/*************************/
+	/*************************/
+	/* SEE IF SHOULD TO BLUR */
+	/*************************/
 
 	if (theNode->Skeleton->AnimNum != PLAYER_ANIM_JUMPJET)													// always blur when jump-jetting
 	{
 		if (theNode->Speed3D < PLAYER_VAPOR_THRESHOLD)				// only add trail if going fast
 			return;
 
-			/* DONT DO BLUR IF PLAYER IS MOVING AWAY FROM CAMERA */
+		/* DONT DO BLUR IF PLAYER IS MOVING AWAY FROM CAMERA */
 
 		FastNormalizeVector(theNode->Delta.x, theNode->Delta.y, theNode->Delta.z, &playerVec);					// calc player motion vector
 		FastNormalizeVector(theNode->Coord.x - gGameViewInfoPtr->cameraPlacement.cameraLocation.x,				// calc vector from camera to player
-							theNode->Coord.y - gGameViewInfoPtr->cameraPlacement.cameraLocation.y,
-							theNode->Coord.z - gGameViewInfoPtr->cameraPlacement.cameraLocation.z,
-							&viewVec);
+			theNode->Coord.y - gGameViewInfoPtr->cameraPlacement.cameraLocation.y,
+			theNode->Coord.z - gGameViewInfoPtr->cameraPlacement.cameraLocation.z,
+			&viewVec);
 
 		dot = OGLVector3D_Dot(&playerVec, &viewVec);															// calc dot product to determine angle
 		if ((dot > .9f) || (dot < -.9f))
@@ -1885,11 +1885,11 @@ float		dot;
 	}
 
 
-			/*******************/
-			/* UPDATE THE BLUR */
-			/*******************/
+	/*******************/
+	/* UPDATE THE BLUR */
+	/*******************/
 
-	for (v = 0; v< theNode->Skeleton->skeletonDefinition->NumBones; v++)
+	for (v = 0; v < theNode->Skeleton->skeletonDefinition->NumBones; v++)
 	{
 		FindCoordOfJoint(theNode, v, &p);
 
@@ -1914,9 +1914,9 @@ float		dot;
 
 /******************* UPDATE PLAYER AUTO AIM ****************************/
 
-static void UpdatePlayerAutoAim(ObjNode *player)
+static void UpdatePlayerAutoAim(ObjNode* player)
 {
-float	tx,tz;
+	float	tx, tz;
 
 	if (gPlayerInfo.autoAimTimer <= 0.0f)
 		return;
@@ -1937,17 +1937,17 @@ float	tx,tz;
 // OUTPUT: true if disabled or killed
 //
 
-static Boolean DoPlayerMovementAndCollision(ObjNode *theNode, Byte aimMode, Boolean useBBoxForTerrain)
+static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Boolean useBBoxForTerrain)
 {
-float				fps = gFramesPerSecondFrac,oldFPS,oldFPSFrac,terrainY;
-OGLPoint3D			oldCoord;
-OGLVector2D			aimVec,deltaVec, accVec;
-OGLMatrix3x3		m;
-static OGLPoint2D origin = {0,0};
-int					numPasses,pass;
-Boolean				killed = false;
+	float				fps = gFramesPerSecondFrac, oldFPS, oldFPSFrac, terrainY;
+	OGLPoint3D			oldCoord;
+	OGLVector2D			aimVec, deltaVec, accVec;
+	OGLMatrix3x3		m;
+	static OGLPoint2D origin = { 0,0 };
+	int					numPasses, pass;
+	Boolean				killed = false;
 
-	if (gPlayerInfo.analogControlX || gPlayerInfo.analogControlZ)	// if player is attempting some control then reset this timer
+	if (gPlayerInfo.analogControlX || gPlayerInfo.analogControlZ || gPlayerInfo.strafeControlX)	// if player is attempting some control then reset this timer
 	{
 		gTimeSinceLastThrust = 0;
 		gForceCameraAlignment = false;								// now that player is moving us, dont force auto-align
@@ -1955,42 +1955,75 @@ Boolean				killed = false;
 	}
 
 
-				/*******************************/
-				/* DO PLAYER-RELATIVE CONTROLS */
-				/*******************************/
+	/*******************************/
+	/* DO PLAYER-RELATIVE CONTROLS */
+	/*******************************/
 
-	if (gGamePrefs.playerRelControls) // (Doesnt seem to be the case for fpv VR mode)
+	if (true) // (Gives better mouse control?) Seems to prevent player from turning when colliding 
 	{
-		float	r,sens;
+		float	rotation, sens;
 
+		// analogControlX is mouse only now
 		sens = gPlayerInfo.analogControlX * fps * CONTROL_SENSITIVITY_PR_TURN;
 		if (theNode->Speed2D > 400.0f)												// turning less sensitive if walking
 			sens *= .5f;
 
-		r = theNode->Rot.y -= sens;													// use x to rotate
+		rotation = theNode->Rot.y -= sens; // Set rotate view (view follows robot rot) with analogControl (mouse)
 
-		theNode->AccelVector.x = sin(r);
-		theNode->AccelVector.y = cos(r);
+
+		float	strafe, movement;
+
+		// We are using the A or D keys (strafing):
+		if (gPlayerInfo.strafeControlX) {
+			// We are only strafing (no forward nor backward):
+			if (gPlayerInfo.analogControlZ == 0) {
+				strafe = theNode->Rot.y + PI/2;
+			}
+			// We are moving forward:
+			else if (gPlayerInfo.analogControlZ < 0) {
+				strafe = theNode->Rot.y - sin(gPlayerInfo.strafeControlX);
+			}
+			// We are moving backward:
+			else if (gPlayerInfo.analogControlZ > 0) {
+				strafe = theNode->Rot.y + sin(gPlayerInfo.strafeControlX);
+			}
+		}
+		// We are just moving with W or S, no strafing:
+		else {
+			strafe = theNode->Rot.y;
+		}
+
+		theNode->AccelVector.x = sin(strafe);
+		theNode->AccelVector.y = cos(strafe);
+
+
+		if (!gPlayerInfo.analogControlZ) {
+			movement = gPlayerInfo.strafeControlX;
+		}
+		else {
+			movement = gPlayerInfo.analogControlZ;
+		}
+
 
 		if (theNode->StatusBits & STATUS_BIT_ONGROUND)
 		{
-			gDelta.x += theNode->AccelVector.x * ((CONTROL_SENSITIVITY_PR * gPlayerInfo.analogControlZ) * (1.1f - gPlayerSlipperyFactor) * fps);
-			gDelta.z += theNode->AccelVector.y * ((CONTROL_SENSITIVITY_PR * gPlayerInfo.analogControlZ) * (1.1f - gPlayerSlipperyFactor) * fps);
+			gDelta.x += theNode->AccelVector.x * ((CONTROL_SENSITIVITY_PR * movement) * (1.1f - gPlayerSlipperyFactor) * fps);
+			gDelta.z += theNode->AccelVector.y * ((CONTROL_SENSITIVITY_PR * movement) * (1.1f - gPlayerSlipperyFactor) * fps);
 		}
 		else
 		{
-			gDelta.x += theNode->AccelVector.x * (CONTROL_SENSITIVITY_AIR_PR * gPlayerInfo.analogControlZ * fps);
-			gDelta.z += theNode->AccelVector.y * (CONTROL_SENSITIVITY_AIR_PR * gPlayerInfo.analogControlZ * fps);
+			gDelta.x += theNode->AccelVector.x * (CONTROL_SENSITIVITY_AIR_PR * movement * fps);
+			gDelta.z += theNode->AccelVector.y * (CONTROL_SENSITIVITY_AIR_PR * movement * fps);
 		}
 
 	}
 
-				/*******************************/
-				/* DO CAMERA-RELATIVE CONTROLS */
-				/*******************************/
-	else
+	/*******************************/
+	/* DO CAMERA-RELATIVE CONTROLS */
+	/*******************************/
+	else // UNUSED for VR for now
 	{
-				/* ROTATE ANALOG ACCELERATION VECTOR BASED ON CAMERA POS & APPLY TO DELTA */
+		/* ROTATE ANALOG ACCELERATION VECTOR BASED ON CAMERA POS & APPLY TO DELTA */
 
 		if ((gPlayerInfo.analogControlX == 0.0f) && (gPlayerInfo.analogControlZ == 0.0f))	// see if not acceling
 		{
@@ -2001,7 +2034,7 @@ Boolean				killed = false;
 			OGLMatrix3x3_SetRotateAboutPoint(&m, &origin, gPlayerToCameraAngle);			// make a 2D rotation matrix camera-rel
 			theNode->AccelVector.x = gPlayerInfo.analogControlX;
 			theNode->AccelVector.y = gPlayerInfo.analogControlZ;
-//			OGLVector2D_Normalize(&theNode->AccelVector, &theNode->AccelVector);
+			//			OGLVector2D_Normalize(&theNode->AccelVector, &theNode->AccelVector);
 			OGLVector2D_Transform(&theNode->AccelVector, &m, &theNode->AccelVector);		// rotate the acceleration vector
 
 
@@ -2021,14 +2054,14 @@ Boolean				killed = false;
 
 
 
-				/**********************************************************/
-				/* TURN PLAYER TO AIM DIRECTION OF ACCELERATION OR MOTION */
-				/**********************************************************/
-				//
-				// Depending on how slippery the terrain is, we aim toward the direction
-				// of motion or the direction of acceleration.  We'll use the gPlayerSlipperyFactor value
-				// to average an aim vector between the two.
-				//
+		/**********************************************************/
+		/* TURN PLAYER TO AIM DIRECTION OF ACCELERATION OR MOTION */
+		/**********************************************************/
+		//
+		// Depending on how slippery the terrain is, we aim toward the direction
+		// of motion or the direction of acceleration.  We'll use the gPlayerSlipperyFactor value
+		// to average an aim vector between the two.
+		//
 
 		if ((aimMode != AIM_MODE_NONE) && (theNode->Speed2D > 0.0f))
 		{
@@ -2041,23 +2074,23 @@ Boolean				killed = false;
 			if (aimMode == AIM_MODE_REVERSE)
 				TurnObjectTowardTarget(theNode, &gCoord, gCoord.x - aimVec.x, gCoord.z - aimVec.y, 8.0f, false);
 			else
-			if (aimMode == AIM_MODE_NORMAL)
-			{
-				float	turnSpeed;
+				if (aimMode == AIM_MODE_NORMAL)
+				{
+					float	turnSpeed;
 
-				if (theNode->Speed2D > 400.0f)					// tweaked numbers for fpv
-					turnSpeed = 20;
-				else
-					turnSpeed = 7;
+					if (theNode->Speed2D > 400.0f)					// tweaked numbers for fpv
+						turnSpeed = 20;
+					else
+						turnSpeed = 7;
 
-				// Still have to figure out why it all goes crazy when player is standing still and turning on himself
+					// Still have to figure out why it all goes crazy when player is standing still and turning on himself
 
-				TurnObjectTowardTarget(theNode, &gCoord, gCoord.x + aimVec.x, gCoord.z + aimVec.y, turnSpeed, false);
-			}
+					TurnObjectTowardTarget(theNode, &gCoord, gCoord.x + aimVec.x, gCoord.z + aimVec.y, turnSpeed, false);
+				}
 		}
 	}
 
-				/* CALC SPEED */
+	/* CALC SPEED */
 
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);					// calc 2D speed value
 	if ((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
@@ -2082,16 +2115,16 @@ Boolean				killed = false;
 	}
 
 
-		/*****************************************/
-		/* PART 1: MOVE AND COLLIDE IN MULTIPASS */
-		/*****************************************/
+	/*****************************************/
+	/* PART 1: MOVE AND COLLIDE IN MULTIPASS */
+	/*****************************************/
 
-		/* SUB-DIVIDE DELTA INTO MANAGABLE LENGTHS */
+	/* SUB-DIVIDE DELTA INTO MANAGABLE LENGTHS */
 
 	oldFPS = gFramesPerSecond;											// remember what fps really is
 	oldFPSFrac = gFramesPerSecondFrac;
 
-	numPasses = (theNode->Speed2D*oldFPSFrac) * (1.0f / DELTA_SUBDIV);	// calc how many subdivisions to create
+	numPasses = (theNode->Speed2D * oldFPSFrac) * (1.0f / DELTA_SUBDIV);	// calc how many subdivisions to create
 	numPasses++;
 
 	gFramesPerSecondFrac *= 1.0f / (float)numPasses;					// adjust frame rate during motion and collision
@@ -2101,7 +2134,7 @@ Boolean				killed = false;
 
 	for (pass = 0; pass < numPasses; pass++)
 	{
-		float	dx,dy,dz;
+		float	dx, dy, dz;
 
 		oldCoord = gCoord;								// remember starting coord
 
@@ -2114,22 +2147,22 @@ Boolean				killed = false;
 
 		if (theNode->MPlatform)						// see if factor in moving platform
 		{
-			ObjNode *plat = theNode->MPlatform;
+			ObjNode* plat = theNode->MPlatform;
 			dx += plat->Delta.x;
 			dy += plat->Delta.y;
 			dz += plat->Delta.z;
 		}
 
-				/* MOVE IT */
+		/* MOVE IT */
 
-		gCoord.x += dx*fps;
-		gCoord.y += dy*fps;
-		gCoord.z += dz*fps;
+		gCoord.x += dx * fps;
+		gCoord.y += dy * fps;
+		gCoord.z += dz * fps;
 
 
-				/******************************/
-				/* DO OBJECT COLLISION DETECT */
-				/******************************/
+		/******************************/
+		/* DO OBJECT COLLISION DETECT */
+		/******************************/
 
 		if (DoRobotCollisionDetect(theNode, useBBoxForTerrain))
 			killed = true;
@@ -2142,14 +2175,14 @@ Boolean				killed = false;
 	gFramesPerSecondFrac = oldFPSFrac;
 
 
-				/*************************/
-				/* CHECK FENCE COLLISION */
-				/*************************/
+	/*************************/
+	/* CHECK FENCE COLLISION */
+	/*************************/
 
 	DoFenceCollision(theNode);
 
 
-				/* CHECK FLOOR */
+	/* CHECK FLOOR */
 
 	terrainY = GetTerrainY(gCoord.x, gCoord.z);
 	gPlayerInfo.distToFloor = gCoord.y + theNode->BBox.min.y - terrainY;				// calc dist to floor
@@ -2168,19 +2201,19 @@ Boolean				killed = false;
 // OUTPUT: true if disabled or killed
 //
 
-static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode *theNode)
+static Boolean DoPlayerMovementAndCollision_JumpJet(ObjNode* theNode)
 {
-float				fps = gFramesPerSecondFrac,oldFPS,oldFPSFrac;
-OGLVector3D			accVec;
-OGLMatrix4x4		m;
-static const OGLVector3D up = {0,1,0};
-Boolean				killed = false;
-OGLPoint3D			oldCoord;
-int					numPasses,pass;
+	float				fps = gFramesPerSecondFrac, oldFPS, oldFPSFrac;
+	OGLVector3D			accVec;
+	OGLMatrix4x4		m;
+	static const OGLVector3D up = { 0,1,0 };
+	Boolean				killed = false;
+	OGLPoint3D			oldCoord;
+	int					numPasses, pass;
 
 
 
-				/* SET INITIAL INFO */
+	/* SET INITIAL INFO */
 
 	theNode->AccelVector.x = theNode->AccelVector.y = 0;							// player has no acceleration control of jump-jet
 
@@ -2189,9 +2222,9 @@ int					numPasses,pass;
 	theNode->Rot.y -= gPlayerInfo.analogControlX * 1.5f * fps;
 
 
-		/* CALC MOTION VECTOR BASED ON AIM OF JUMP-JET ANIM */
+	/* CALC MOTION VECTOR BASED ON AIM OF JUMP-JET ANIM */
 
-	FindJointFullMatrix(theNode,  PLAYER_JOINT_BASE, &m);							// get matrix from skeleton joint
+	FindJointFullMatrix(theNode, PLAYER_JOINT_BASE, &m);							// get matrix from skeleton joint
 	OGLVector3D_Transform(&up, &m, &accVec);										// calculate a motion vector
 
 				/* CALC SPEED */
@@ -2207,16 +2240,16 @@ int					numPasses,pass;
 	}
 
 
-		/*****************************************/
-		/* PART 1: MOVE AND COLLIDE IN MULTIPASS */
-		/*****************************************/
+	/*****************************************/
+	/* PART 1: MOVE AND COLLIDE IN MULTIPASS */
+	/*****************************************/
 
-		/* SUB-DIVIDE DELTA INTO MANAGABLE LENGTHS */
+	/* SUB-DIVIDE DELTA INTO MANAGABLE LENGTHS */
 
 	oldFPS = gFramesPerSecond;											// remember what fps really is
 	oldFPSFrac = gFramesPerSecondFrac;
 
-	numPasses = (theNode->Speed2D*oldFPSFrac) * (1.0f / DELTA_SUBDIV);	// calc how many subdivisions to create
+	numPasses = (theNode->Speed2D * oldFPSFrac) * (1.0f / DELTA_SUBDIV);	// calc how many subdivisions to create
 	numPasses++;
 
 	gFramesPerSecondFrac *= 1.0f / (float)numPasses;					// adjust frame rate during motion and collision
@@ -2226,7 +2259,7 @@ int					numPasses,pass;
 
 	for (pass = 0; pass < numPasses; pass++)
 	{
-		float	dx,dy,dz;
+		float	dx, dy, dz;
 
 		oldCoord = gCoord;								// remember starting coord
 
@@ -2238,7 +2271,7 @@ int					numPasses,pass;
 		dz = gDelta.z;
 
 
-					/* MOVE IT */
+		/* MOVE IT */
 
 		if (theNode->JumpJetEnginesOff)
 		{
@@ -2258,14 +2291,14 @@ int					numPasses,pass;
 		gDelta.y = accVec.y * gPlayerInfo.jumpJetSpeed;
 		gDelta.z = accVec.z * gPlayerInfo.jumpJetSpeed;
 
-		gCoord.x += dx*fps;
-		gCoord.y += dy*fps;
-		gCoord.z += dz*fps;
+		gCoord.x += dx * fps;
+		gCoord.y += dy * fps;
+		gCoord.z += dz * fps;
 
 
-					/******************************/
-					/* DO OBJECT COLLISION DETECT */
-					/******************************/
+		/******************************/
+		/* DO OBJECT COLLISION DETECT */
+		/******************************/
 
 		killed = DoRobotCollisionDetect(theNode, true);
 
@@ -2275,9 +2308,9 @@ int					numPasses,pass;
 	gFramesPerSecond = oldFPS;										// restore real FPS values
 	gFramesPerSecondFrac = oldFPSFrac;
 
-				/*************************/
-				/* CHECK FENCE COLLISION */
-				/*************************/
+	/*************************/
+	/* CHECK FENCE COLLISION */
+	/*************************/
 
 	DoFenceCollision(theNode);
 
@@ -2285,18 +2318,18 @@ int					numPasses,pass;
 
 
 
-				/******************************/
-				/* DO JUMP-JET FIST COLLISION */
-				/******************************/
+	/******************************/
+	/* DO JUMP-JET FIST COLLISION */
+	/******************************/
 
 	if (!killed)
 	{
-		static const OGLPoint3D fistOff = {0,-50,0};
-		OGLPoint3D	fistCoord1,fistCoord2;
+		static const OGLPoint3D fistOff = { 0,-50,0 };
+		OGLPoint3D	fistCoord1, fistCoord2;
 		int			i;
-		ObjNode		*hitObj;
+		ObjNode* hitObj;
 
-					/* CALC COORD TO TEST */
+		/* CALC COORD TO TEST */
 
 		FindCoordOnJoint(theNode, PLAYER_JOINT_RIGHTHAND, &fistOff, &fistCoord1);			// calc coord of fists
 		FindCoordOnJoint(theNode, PLAYER_JOINT_LEFTHAND, &fistOff, &fistCoord2);
@@ -2305,10 +2338,10 @@ int					numPasses,pass;
 		fistCoord1.y = (fistCoord1.y + fistCoord2.y) * .5f;
 		fistCoord1.z = (fistCoord1.z + fistCoord2.z) * .5f;
 
-						/* SEE IF HIT ANYTHING */
+		/* SEE IF HIT ANYTHING */
 
 		if (DoSimpleBoxCollision(fistCoord1.y + 30.0f, fistCoord1.y - 30.0f, fistCoord1.x - 30.0f, fistCoord1.x + 30.0f,
-								fistCoord1.z + 30.0f, fistCoord1.z - 30.0f, CTYPE_MISC|CTYPE_ENEMY))
+			fistCoord1.z + 30.0f, fistCoord1.z - 30.0f, CTYPE_MISC | CTYPE_ENEMY))
 		{
 			for (i = 0; i < gNumCollisions; i++)										// scan hits for a handler
 			{
@@ -2331,18 +2364,18 @@ int					numPasses,pass;
 // OUTPUT: true if disabled or killed
 //
 
-static void DoPlayerMovementAndCollision_Bubble(ObjNode *theNode)
+static void DoPlayerMovementAndCollision_Bubble(ObjNode* theNode)
 {
-float				fps = gFramesPerSecondFrac;
-OGLVector2D			aimVec,deltaVec, accVec;
-OGLMatrix3x3		m;
-static OGLPoint2D origin = {0,0};
-Boolean				hit = false;
-float				oldRadius;
+	float				fps = gFramesPerSecondFrac;
+	OGLVector2D			aimVec, deltaVec, accVec;
+	OGLMatrix3x3		m;
+	static OGLPoint2D origin = { 0,0 };
+	Boolean				hit = false;
+	float				oldRadius;
 
-				/*******************************/
-				/* DO PLAYER-RELATIVE CONTROLS */
-				/*******************************/
+	/*******************************/
+	/* DO PLAYER-RELATIVE CONTROLS */
+	/*******************************/
 
 	if (gGamePrefs.playerRelControls)
 	{
@@ -2366,15 +2399,15 @@ float				oldRadius;
 
 	}
 
-				/*******************************/
-				/* DO CAMERA-RELATIVE CONTROLS */
-				/*******************************/
+	/*******************************/
+	/* DO CAMERA-RELATIVE CONTROLS */
+	/*******************************/
 
 	else
 	{
 
 
-				/* ROTATE ANALOG ACCELERATION VECTOR BASED ON CAMERA POS & APPLY TO DELTA */
+		/* ROTATE ANALOG ACCELERATION VECTOR BASED ON CAMERA POS & APPLY TO DELTA */
 
 		OGLMatrix3x3_SetRotateAboutPoint(&m, &origin, gPlayerToCameraAngle);			// make a 2D rotation matrix camera-rel
 		theNode->AccelVector.x = gPlayerInfo.analogControlX;
@@ -2387,14 +2420,14 @@ float				oldRadius;
 		gDelta.x += theNode->AccelVector.x * CONTROL_SENSITIVITY * (1.1f - gPlayerSlipperyFactor);
 		gDelta.z += theNode->AccelVector.y * CONTROL_SENSITIVITY * (1.1f - gPlayerSlipperyFactor);
 
-				/**********************************************************/
-				/* TURN PLAYER TO AIM DIRECTION OF ACCELERATION OR MOTION */
-				/**********************************************************/
-				//
-				// Depending on how slippery the terrain is, we aim toward the direction
-				// of motion or the direction of acceleration.  We'll use the gPlayerSlipperyFactor value
-				// to average an aim vector between the two.
-				//
+		/**********************************************************/
+		/* TURN PLAYER TO AIM DIRECTION OF ACCELERATION OR MOTION */
+		/**********************************************************/
+		//
+		// Depending on how slippery the terrain is, we aim toward the direction
+		// of motion or the direction of acceleration.  We'll use the gPlayerSlipperyFactor value
+		// to average an aim vector between the two.
+		//
 
 		FastNormalizeVector2D(gDelta.x, gDelta.z, &deltaVec, true);
 		FastNormalizeVector2D(theNode->AccelVector.x, theNode->AccelVector.y, &accVec, true);
@@ -2405,7 +2438,7 @@ float				oldRadius;
 		TurnObjectTowardTarget(theNode, &gCoord, gCoord.x + aimVec.x, gCoord.z + aimVec.y, 8.0f, false);
 	}
 
-				/* CALC SPEED */
+	/* CALC SPEED */
 
 	VectorLength2D(theNode->Speed2D, gDelta.x, gDelta.z);					// calc 2D speed value
 	if ((theNode->Speed2D >= 0.0f) && (theNode->Speed2D < 10000000.0f))		// check for weird NaN bug
@@ -2430,35 +2463,35 @@ float				oldRadius;
 	}
 
 
-			/* MOVE IT */
+	/* MOVE IT */
 
-	gCoord.x += gDelta.x*fps;
-	gCoord.y += gDelta.y*fps;
-	gCoord.z += gDelta.z*fps;
+	gCoord.x += gDelta.x * fps;
+	gCoord.y += gDelta.y * fps;
+	gCoord.z += gDelta.z * fps;
 
 
-			/******************************/
-			/* DO OBJECT COLLISION DETECT */
-			/******************************/
-			//
-			// for the bubble, we do only rudimentary collision to see
-			// if we need to pop the bubble
-			//
+	/******************************/
+	/* DO OBJECT COLLISION DETECT */
+	/******************************/
+	//
+	// for the bubble, we do only rudimentary collision to see
+	// if we need to pop the bubble
+	//
 
 	if (DoSimpleBoxCollision(gCoord.y + gSoapBubble->TopOff, gCoord.y + gSoapBubble->BottomOff,
-							 gCoord.x + gSoapBubble->LeftOff, gCoord.x + gSoapBubble->RightOff,
-							 gCoord.z + gSoapBubble->FrontOff, gCoord.z + gSoapBubble->BackOff,
-							CTYPE_MISC|CTYPE_ENEMY|CTYPE_TRIGGER))
+		gCoord.x + gSoapBubble->LeftOff, gCoord.x + gSoapBubble->RightOff,
+		gCoord.z + gSoapBubble->FrontOff, gCoord.z + gSoapBubble->BackOff,
+		CTYPE_MISC | CTYPE_ENEMY | CTYPE_TRIGGER))
 	{
 		hit = true;
 	}
 
-				/*************************/
-				/* CHECK FENCE COLLISION */
-				/*************************/
+	/*************************/
+	/* CHECK FENCE COLLISION */
+	/*************************/
 
 	oldRadius = theNode->BoundingSphereRadius;								// tweak the radius for this
-	theNode->BoundingSphereRadius =  gSoapBubble->BBox.max.x;
+	theNode->BoundingSphereRadius = gSoapBubble->BBox.max.x;
 	if (DoFenceCollision(theNode) || hit)
 	{
 		PopSoapBubble(gSoapBubble);
@@ -2474,30 +2507,30 @@ float				oldRadius;
 // Applies friction to the gDeltas
 //
 
-static void DoRobotFrictionAndGravity(ObjNode *theNode, float friction)
+static void DoRobotFrictionAndGravity(ObjNode* theNode, float friction)
 {
-OGLVector2D	v;
-float	x,z,fps;
+	OGLVector2D	v;
+	float	x, z, fps;
 
 	fps = gFramesPerSecondFrac;
 
-			/**************/
-			/* DO GRAVITY */
-			/**************/
+	/**************/
+	/* DO GRAVITY */
+	/**************/
 
-	gDelta.y -= gGravity*fps;					// add gravity
+	gDelta.y -= gGravity * fps;					// add gravity
 
 	if (gDelta.y < 0.0f)							// if falling, keep dy at least -1.0 to avoid collision jitter on platforms
 		if (gDelta.y > (-20.0f * fps))
 			gDelta.y = (-20.0f * fps);
 
 
-			/***************/
-			/* DO FRICTION */
-			/***************/
-			//
-			// Dont do friction if player is pressing controls
-			//
+	/***************/
+	/* DO FRICTION */
+	/***************/
+	//
+	// Dont do friction if player is pressing controls
+	//
 
 	if (!gGamePrefs.playerRelControls)
 	{
@@ -2506,17 +2539,17 @@ float	x,z,fps;
 	}
 	else										// with player relative controls, do heavier friction in some cases
 	{
-		switch(theNode->Skeleton->AnimNum)
+		switch (theNode->Skeleton->AnimNum)
 		{
-			case	PLAYER_ANIM_STAND:
-			case	PLAYER_ANIM_WALK:
-			case	PLAYER_ANIM_WALKWITHGUN:
-			case	PLAYER_ANIM_STANDWITHGUN:
-			case	PLAYER_ANIM_PUNCH:
-			case	PLAYER_ANIM_PICKUPDEPOSIT:
-			case	PLAYER_ANIM_PICKUPANDHOLDGUN:
-					friction *= 2.0f;
-					break;
+		case	PLAYER_ANIM_STAND:
+		case	PLAYER_ANIM_WALK:
+		case	PLAYER_ANIM_WALKWITHGUN:
+		case	PLAYER_ANIM_STANDWITHGUN:
+		case	PLAYER_ANIM_PUNCH:
+		case	PLAYER_ANIM_PICKUPDEPOSIT:
+		case	PLAYER_ANIM_PICKUPANDHOLDGUN:
+			friction *= 2.0f;
+			break;
 		}
 	}
 
@@ -2538,12 +2571,12 @@ float	x,z,fps;
 			gDelta.x = 0;
 	}
 	else
-	if (gDelta.x > 0.0f)
-	{
-		gDelta.x += x;
-		if (gDelta.x < 0.0f)
-			gDelta.x = 0;
-	}
+		if (gDelta.x > 0.0f)
+		{
+			gDelta.x += x;
+			if (gDelta.x < 0.0f)
+				gDelta.x = 0;
+		}
 
 	if (gDelta.z < 0.0f)
 	{
@@ -2552,12 +2585,12 @@ float	x,z,fps;
 			gDelta.z = 0;
 	}
 	else
-	if (gDelta.z > 0.0f)
-	{
-		gDelta.z += z;
-		if (gDelta.z < 0.0f)
-			gDelta.z = 0;
-	}
+		if (gDelta.z > 0.0f)
+		{
+			gDelta.z += z;
+			if (gDelta.z < 0.0f)
+				gDelta.z = 0;
+		}
 
 	if ((gDelta.x == 0.0f) && (gDelta.z == 0.0f))
 	{
@@ -2576,17 +2609,17 @@ float	x,z,fps;
 // OUTPUT: true = disabled/killed
 //
 
-static Boolean DoRobotCollisionDetect(ObjNode *theNode, Boolean useBBoxForTerrain)
+static Boolean DoRobotCollisionDetect(ObjNode* theNode, Boolean useBBoxForTerrain)
 {
-short		i;
-ObjNode		*hitObj;
-unsigned long	ctype;
-u_char		sides;
-float		distToFloor, terrainY, fps = gFramesPerSecondFrac;
-float		bottomOff;
-Boolean		killed = false;
+	short		i;
+	ObjNode* hitObj;
+	unsigned long	ctype;
+	u_char		sides;
+	float		distToFloor, terrainY, fps = gFramesPerSecondFrac;
+	float		bottomOff;
+	Boolean		killed = false;
 
-			/* DETERMINE CTYPE BITS TO CHECK FOR */
+	/* DETERMINE CTYPE BITS TO CHECK FOR */
 
 	ctype = PLAYER_COLLISION_CTYPE;
 
@@ -2608,10 +2641,10 @@ Boolean		killed = false;
 
 	sides = HandleCollisions(theNode, ctype, -.3);
 
-			/* SCAN FOR INTERESTING STUFF */
+	/* SCAN FOR INTERESTING STUFF */
 
 
-	for (i=0; i < gNumCollisions; i++)
+	for (i = 0; i < gNumCollisions; i++)
 	{
 		if (gCollisionList[i].type == COLLISION_TYPE_OBJ)
 		{
@@ -2650,16 +2683,16 @@ Boolean		killed = false;
 		}
 	}
 
-		/*************************************/
-		/* CHECK & HANDLE TERRAIN  COLLISION */
-		/*************************************/
+	/*************************************/
+	/* CHECK & HANDLE TERRAIN  COLLISION */
+	/*************************************/
 
 	if (useBBoxForTerrain)
 		bottomOff = theNode->BBox.min.y;							// use bbox for bottom
 	else
 		bottomOff = theNode->BottomOff;								// use collision box for bottom
 
-	terrainY =  GetTerrainY(gCoord.x, gCoord.z);					// get terrain Y
+	terrainY = GetTerrainY(gCoord.x, gCoord.z);					// get terrain Y
 
 	distToFloor = (gCoord.y + bottomOff) - terrainY;				// calc amount I'm above or under
 
@@ -2670,38 +2703,38 @@ Boolean		killed = false;
 		theNode->StatusBits |= STATUS_BIT_ONGROUND;
 		gPlayerSlipperyFactor = gTileSlipperyFactor;				// use this slippery factor
 
-		switch(gLevelNum)
+		switch (gLevelNum)
 		{
-			case	LEVEL_NUM_BLOBBOSS:								// if touch blob boss ground, then hurt player and bounce back up
-					PlayerLoseHealth(.25, PLAYER_DEATH_TYPE_EXPLODE);
-					gDelta.y = 2500.0f;
-					PlayEffect3D(EFFECT_SLIMEBOUNCE, &gCoord);
-					break;
+		case	LEVEL_NUM_BLOBBOSS:								// if touch blob boss ground, then hurt player and bounce back up
+			PlayerLoseHealth(.25, PLAYER_DEATH_TYPE_EXPLODE);
+			gDelta.y = 2500.0f;
+			PlayEffect3D(EFFECT_SLIMEBOUNCE, &gCoord);
+			break;
 
-			case	LEVEL_NUM_CLOUD:								// see if touch electric floor
-					if (gTileAttribFlags & (TILE_ATTRIB_ELECTROCUTE_AREA0|TILE_ATTRIB_ELECTROCUTE_AREA1))
-					{
-						if (gTileAttribFlags & TILE_ATTRIB_ELECTROCUTE_AREA0)	// check area #0
-						{
-							if (!gBumperCarGateBlown[0])
-								PlayerTouchedElectricFloor(theNode);
-						}
-						else													// check area #1
-						{
-							if (!gBumperCarGateBlown[1])
-								PlayerTouchedElectricFloor(theNode);
-						}
-					}
-					break;
+		case	LEVEL_NUM_CLOUD:								// see if touch electric floor
+			if (gTileAttribFlags & (TILE_ATTRIB_ELECTROCUTE_AREA0 | TILE_ATTRIB_ELECTROCUTE_AREA1))
+			{
+				if (gTileAttribFlags & TILE_ATTRIB_ELECTROCUTE_AREA0)	// check area #0
+				{
+					if (!gBumperCarGateBlown[0])
+						PlayerTouchedElectricFloor(theNode);
+				}
+				else													// check area #1
+				{
+					if (!gBumperCarGateBlown[1])
+						PlayerTouchedElectricFloor(theNode);
+				}
+			}
+			break;
 		}
 	}
 
 
-			/* DEAL WITH SLOPES */
-			//
-			// Using the floor normal here, apply some deltas to it.
-			// Only apply slopes when on the ground (or really close to it)
-			//
+	/* DEAL WITH SLOPES */
+	//
+	// Using the floor normal here, apply some deltas to it.
+	// Only apply slopes when on the ground (or really close to it)
+	//
 
 	if ((fabs(gPlayerInfo.analogControlX) < 0.5f) && (fabs(gPlayerInfo.analogControlZ) < 0.5f))			// only do slopes if player isn't controlling
 	{
@@ -2712,50 +2745,50 @@ Boolean		killed = false;
 		}
 	}
 
-			/**************************/
-			/* SEE IF IN WATER VOLUME */
-			/**************************/
+	/**************************/
+	/* SEE IF IN WATER VOLUME */
+	/**************************/
 
 	if (!killed)
 	{
 		int		patchNum;
 		Boolean	wasInWater;
 
-					/* REMEMBER IF ALREADY IN WATER */
+		/* REMEMBER IF ALREADY IN WATER */
 
 		if (theNode->StatusBits & STATUS_BIT_UNDERWATER)
 			wasInWater = true;
 		else
 			wasInWater = false;
 
-					/* CHECK IF IN WATER NOW */
+		/* CHECK IF IN WATER NOW */
 
-		if (DoWaterCollisionDetect(theNode, gCoord.x, gCoord.y+theNode->BottomOff + 50.0f, gCoord.z, &patchNum))
+		if (DoWaterCollisionDetect(theNode, gCoord.x, gCoord.y + theNode->BottomOff + 50.0f, gCoord.z, &patchNum))
 		{
 			gPlayerInfo.waterPatch = patchNum;
 
 			gCoord.y = gWaterBBox[patchNum].max.y;
 
-			switch(gWaterList[patchNum].type)
+			switch (gWaterList[patchNum].type)
 			{
-					/* JUNGLE MUD */
+				/* JUNGLE MUD */
 
-				case	WATER_TYPE_MUD:
-						ApplyFrictionToDeltas(300.0f, &gDelta);									// mud is viscous so slow player
-						killed = PlayerLoseHealth(.3f * fps, PLAYER_DEATH_TYPE_DROWN);			// lose health
-						MakeSteam(theNode, gCoord.x, gCoord.y, gCoord.z);
-						break;
+			case	WATER_TYPE_MUD:
+				ApplyFrictionToDeltas(300.0f, &gDelta);									// mud is viscous so slow player
+				killed = PlayerLoseHealth(.3f * fps, PLAYER_DEATH_TYPE_DROWN);			// lose health
+				MakeSteam(theNode, gCoord.x, gCoord.y, gCoord.z);
+				break;
 
-				case	WATER_TYPE_LAVA:
-						ApplyFrictionToDeltas(2000.0f, &gDelta);								// lava is viscous so slow player
-						killed = PlayerLoseHealth(.5f * fps, PLAYER_DEATH_TYPE_EXPLODE);		// lose health
-						BurnFire(theNode, gCoord.x, gCoord.y, gCoord.z, true, PARTICLE_SObjType_Fire, 4.0, PARTICLE_FLAGS_ALLAIM);
-						break;
+			case	WATER_TYPE_LAVA:
+				ApplyFrictionToDeltas(2000.0f, &gDelta);								// lava is viscous so slow player
+				killed = PlayerLoseHealth(.5f * fps, PLAYER_DEATH_TYPE_EXPLODE);		// lose health
+				BurnFire(theNode, gCoord.x, gCoord.y, gCoord.z, true, PARTICLE_SObjType_Fire, 4.0, PARTICLE_FLAGS_ALLAIM);
+				break;
 
-						/* GOOD OLD ZAPPING H2O */
-				default:
-						if (!wasInWater)
-							PlayerEntersWater(theNode, patchNum);
+				/* GOOD OLD ZAPPING H2O */
+			default:
+				if (!wasInWater)
+					PlayerEntersWater(theNode, patchNum);
 			}
 		}
 	}
@@ -2770,21 +2803,21 @@ Boolean		killed = false;
 // Handles fist collision with punchable objects
 //
 
-static void CheckPunchCollision(ObjNode *player)
+static void CheckPunchCollision(ObjNode* player)
 {
-static OGLPoint3D fistOff = {0,-12 ,0};
-OGLPoint3D	fistCoord;
-int			i;
-ObjNode		*hitObj;
-Boolean		endPunch;
-float		fistSize = 30.0f * gPlayerInfo.scale;
+	static OGLPoint3D fistOff = { 0,-12 ,0 };
+	OGLPoint3D	fistCoord;
+	int			i;
+	ObjNode* hitObj;
+	Boolean		endPunch;
+	float		fistSize = 30.0f * gPlayerInfo.scale;
 
 	FindCoordOnJoint(player, PLAYER_JOINT_RIGHTHAND, &fistOff, &fistCoord);			// calc coord of fist
 
 	if (DoSimpleBoxCollision(fistCoord.y + fistSize, fistCoord.y - fistSize,
-							 fistCoord.x - fistSize, fistCoord.x + fistSize,
-							 fistCoord.z + fistSize, fistCoord.z - fistSize,
-							 CTYPE_MISC|CTYPE_ENEMY|CTYPE_TRIGGER|CTYPE_POWERUP))
+		fistCoord.x - fistSize, fistCoord.x + fistSize,
+		fistCoord.z + fistSize, fistCoord.z - fistSize,
+		CTYPE_MISC | CTYPE_ENEMY | CTYPE_TRIGGER | CTYPE_POWERUP))
 	{
 		for (i = 0; i < gNumCollisions; i++)										// affect all hit objects
 		{
@@ -2816,18 +2849,18 @@ float		fistSize = 30.0f * gPlayerInfo.scale;
 // INPUT:	theNode = the node of the player
 //
 
-static void CheckPlayerActionControls(ObjNode *theNode)
+static void CheckPlayerActionControls(ObjNode* theNode)
 {
-		/* SEE IF DO CHEAT */
+	/* SEE IF DO CHEAT */
 
 	if (GetKeyState(SDL_SCANCODE_B) &&
 		GetKeyState(SDL_SCANCODE_R) &&
 		GetKeyState(SDL_SCANCODE_I))
 	{
 		if (gPlayerInfo.lives < 3)
-			gPlayerInfo.lives 	= 3;
-		gPlayerInfo.health 	= 1.0;
-		gPlayerInfo.fuel 	= 1.0;
+			gPlayerInfo.lives = 3;
+		gPlayerInfo.health = 1.0;
+		gPlayerInfo.fuel = 1.0;
 		gPlayerInfo.jumpJet = 1.0;
 		gPlayerInfo.weaponInventory[6].type = WEAPON_TYPE_SUPERNOVA;
 		gPlayerInfo.weaponInventory[6].quantity = 99;
@@ -2835,9 +2868,9 @@ static void CheckPlayerActionControls(ObjNode *theNode)
 		gPlayerInfo.weaponInventory[7].quantity = 99;
 	}
 
-			/***************/
-			/* SEE IF JUMP */
-			/***************/
+	/***************/
+	/* SEE IF JUMP */
+	/***************/
 
 	if (GetNewNeedState(kNeed_Jump))										// see if user pressed the key
 	{
@@ -2855,13 +2888,13 @@ static void CheckPlayerActionControls(ObjNode *theNode)
 				theNode->Rot.y = gCannon->Rot.y + PI;
 				MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_CLIMBINTO, 7.0);
 				StartCannonFuse(gCannon);
-				gCameraUserRotY = -PI/2;									// swing camera to side
+				gCameraUserRotY = -PI / 2;									// swing camera to side
 				DisableHelpType(HELP_MESSAGE_INTOCANNON);
 				goto no_jump;
 			}
 		}
 
-			/* CHECK JUMP-JET */
+		/* CHECK JUMP-JET */
 
 		if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP) ||
 			(theNode->Skeleton->AnimNum == PLAYER_ANIM_FALL))			// if already jumping or falling then try Jump Jet
@@ -2869,38 +2902,38 @@ static void CheckPlayerActionControls(ObjNode *theNode)
 			if (fabs(gDelta.y) < 800.0f)								// do it now if near apex of jump
 				StartJumpJet(theNode);
 			else
-			if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)			// not @ apex, but if already jumping then tag to do JJ @ apex
-				gDoJumpJetAtApex = true;
-			else
-			if (gPlayerInfo.distToFloor > 200.0f)						// not @ apex, but if falling still allow JJ if high enough off ground
-				StartJumpJet(theNode);
+				if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMP)			// not @ apex, but if already jumping then tag to do JJ @ apex
+					gDoJumpJetAtApex = true;
+				else
+					if (gPlayerInfo.distToFloor > 200.0f)						// not @ apex, but if falling still allow JJ if high enough off ground
+						StartJumpJet(theNode);
 		}
 
-			/* CHECK REGULAR JUMP */
+		/* CHECK REGULAR JUMP */
 
 		else
-		if ((theNode->StatusBits & STATUS_BIT_ONGROUND)	|| (gPlayerInfo.distToFloor < 15.0f))		// must be on something solid
-		{
-			MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_JUMP, 5.0f);
-			PlayEffect3D(EFFECT_JUMP, &gCoord);
-
-			gDoJumpJetAtApex = false;
-
-			gDelta.y += JUMP_DELTA;
-
-			if (theNode->MPlatform != nil)			// if jumping off of mplatform then also use platform's deltas
+			if ((theNode->StatusBits & STATUS_BIT_ONGROUND) || (gPlayerInfo.distToFloor < 15.0f))		// must be on something solid
 			{
-				gDelta.x += theNode->MPlatform->Delta.x;
-				gDelta.y += theNode->MPlatform->Delta.y;
-				gDelta.z += theNode->MPlatform->Delta.z;
+				MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_JUMP, 5.0f);
+				PlayEffect3D(EFFECT_JUMP, &gCoord);
+
+				gDoJumpJetAtApex = false;
+
+				gDelta.y += JUMP_DELTA;
+
+				if (theNode->MPlatform != nil)			// if jumping off of mplatform then also use platform's deltas
+				{
+					gDelta.x += theNode->MPlatform->Delta.x;
+					gDelta.y += theNode->MPlatform->Delta.y;
+					gDelta.z += theNode->MPlatform->Delta.z;
+				}
 			}
-		}
 	}
 no_jump:
 
-		/******************/
-		/* HANDLE WEAPONS */
-		/******************/
+	/******************/
+	/* HANDLE WEAPONS */
+	/******************/
 
 	CheckPOWControls(theNode);
 }
@@ -2908,7 +2941,7 @@ no_jump:
 
 /******************* START JUMPJET *********************/
 
-static void StartJumpJet(ObjNode *theNode)
+static void StartJumpJet(ObjNode* theNode)
 {
 	if (!gResetJumpJet)								// cannot do this until jump jet has been reset
 		return;
@@ -2927,7 +2960,7 @@ static void StartJumpJet(ObjNode *theNode)
 
 	gResetJumpJet = false;
 
-			/* SET ANIM */
+	/* SET ANIM */
 
 	if (gPlayerInfo.scaleRatio > 1.0f)				// do special version of player is giant
 	{
@@ -2938,26 +2971,26 @@ static void StartJumpJet(ObjNode *theNode)
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_JUMPJET, 6.0f);
 
 
-			/* SET SOME VARIABLES */
+	/* SET SOME VARIABLES */
 
 	gDelta.y = 0;
 	gPlayerInfo.jumpJetSpeed = 0;
 	theNode->JumpJetEnginesOff = false;
 
 
-			/* START PARTICLES */
+	/* START PARTICLES */
 
 	gPlayerInfo.jjParticleGroup[0] = -1;			// white sparks
-	gPlayerInfo.jjParticleMagic[0]	= 0;
-	gPlayerInfo.jjParticleTimer[0]	= 0;
+	gPlayerInfo.jjParticleMagic[0] = 0;
+	gPlayerInfo.jjParticleTimer[0] = 0;
 
 	gPlayerInfo.jjParticleGroup[1] = -1;			// smoke
-	gPlayerInfo.jjParticleMagic[1]	= 0;
-	gPlayerInfo.jjParticleTimer[1]	= 0;
+	gPlayerInfo.jjParticleMagic[1] = 0;
+	gPlayerInfo.jjParticleTimer[1] = 0;
 
 
 
-		/* CREATE SPARKLE */
+	/* CREATE SPARKLE */
 
 	CreatePlayerJumpJetSparkles(theNode);
 
@@ -2967,7 +3000,7 @@ static void StartJumpJet(ObjNode *theNode)
 
 /**************** END JUMPJET *****************/
 
-static void EndJumpJet(ObjNode *theNode)
+static void EndJumpJet(ObjNode* theNode)
 {
 	DeleteSparkle(theNode->Sparkles[PLAYER_SPARKLE_LEFTFOOT]);							// delete sparkles on feet
 	theNode->Sparkles[PLAYER_SPARKLE_LEFTFOOT] = -1;
@@ -2978,20 +3011,20 @@ static void EndJumpJet(ObjNode *theNode)
 
 /****************** UPDATE JUMP JET PARTICLES ********************/
 
-static void UpdateJumpJetParticles(ObjNode *theNode)
+static void UpdateJumpJetParticles(ObjNode* theNode)
 {
-float	fps = gFramesPerSecondFrac;
-int		particleGroup,magicNum;
-NewParticleGroupDefType	groupDef;
-NewParticleDefType	newParticleDef;
-OGLVector3D			d;
-OGLPoint3D			p;
-int					i;
-float				x,y,z;
-static const OGLPoint3D		particleBaseOff = {0,-100,0};
-OGLPoint3D			particleBase;
+	float	fps = gFramesPerSecondFrac;
+	int		particleGroup, magicNum;
+	NewParticleGroupDefType	groupDef;
+	NewParticleDefType	newParticleDef;
+	OGLVector3D			d;
+	OGLPoint3D			p;
+	int					i;
+	float				x, y, z;
+	static const OGLPoint3D		particleBaseOff = { 0,-100,0 };
+	OGLPoint3D			particleBase;
 
-				/* CALC FOOT POINT */
+	/* CALC FOOT POINT */
 
 	FindCoordOnJoint(theNode, PLAYER_JOINT_BASE, &particleBaseOff, &particleBase);
 	x = particleBase.x;
@@ -2999,33 +3032,33 @@ OGLPoint3D			particleBase;
 	z = particleBase.z;
 
 
-			/*********************/
-			/* MAKE WHITE SPARKS */
-			/*********************/
+	/*********************/
+	/* MAKE WHITE SPARKS */
+	/*********************/
 
 	gPlayerInfo.jjParticleTimer[0] -= fps;											// see if add particles
 	if (gPlayerInfo.jjParticleTimer[0] <= 0.0f)
 	{
 		gPlayerInfo.jjParticleTimer[0] += .03f;									// reset timer
 
-		particleGroup 	= gPlayerInfo.jjParticleGroup[0];
-		magicNum 		= gPlayerInfo.jjParticleMagic[0];
+		particleGroup = gPlayerInfo.jjParticleGroup[0];
+		magicNum = gPlayerInfo.jjParticleMagic[0];
 
 		if ((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
 		{
 			gPlayerInfo.jjParticleMagic[0] = magicNum = MyRandomLong();			// generate a random magic num
 
-			groupDef.magicNum				= magicNum;
-			groupDef.type					= PARTICLE_TYPE_FALLINGSPARKS;
-			groupDef.flags					= PARTICLE_FLAGS_DONTCHECKGROUND;
-			groupDef.gravity				= 800;
-			groupDef.magnetism				= 0;
-			groupDef.baseScale				= 20.0f * gPlayerInfo.scaleRatio;
-			groupDef.decayRate				= .8;
-			groupDef.fadeRate				= 1.4;
-			groupDef.particleTextureNum		= PARTICLE_SObjType_WhiteSpark2;
-			groupDef.srcBlend				= GL_SRC_ALPHA;
-			groupDef.dstBlend				= GL_ONE;
+			groupDef.magicNum = magicNum;
+			groupDef.type = PARTICLE_TYPE_FALLINGSPARKS;
+			groupDef.flags = PARTICLE_FLAGS_DONTCHECKGROUND;
+			groupDef.gravity = 800;
+			groupDef.magnetism = 0;
+			groupDef.baseScale = 20.0f * gPlayerInfo.scaleRatio;
+			groupDef.decayRate = .8;
+			groupDef.fadeRate = 1.4;
+			groupDef.particleTextureNum = PARTICLE_SObjType_WhiteSpark2;
+			groupDef.srcBlend = GL_SRC_ALPHA;
+			groupDef.dstBlend = GL_ONE;
 			gPlayerInfo.jjParticleGroup[0] = particleGroup = NewParticleGroup(&groupDef);
 		}
 
@@ -3041,13 +3074,13 @@ OGLPoint3D			particleBase;
 				d.y = RandomFloat2() * 140.0f;
 				d.z = RandomFloat2() * 140.0f;
 
-				newParticleDef.groupNum		= particleGroup;
-				newParticleDef.where		= &p;
-				newParticleDef.delta		= &d;
-				newParticleDef.scale		= 1.0f;
-				newParticleDef.rotZ			= 0;
-				newParticleDef.rotDZ		= 0;
-				newParticleDef.alpha		= 1.0;
+				newParticleDef.groupNum = particleGroup;
+				newParticleDef.where = &p;
+				newParticleDef.delta = &d;
+				newParticleDef.scale = 1.0f;
+				newParticleDef.rotZ = 0;
+				newParticleDef.rotDZ = 0;
+				newParticleDef.alpha = 1.0;
 				if (AddParticleToGroup(&newParticleDef))
 				{
 					gPlayerInfo.jjParticleGroup[0] = -1;
@@ -3058,33 +3091,33 @@ OGLPoint3D			particleBase;
 	}
 
 
-			/**************/
-			/* MAKE SMOKE */
-			/**************/
+	/**************/
+	/* MAKE SMOKE */
+	/**************/
 
 	gPlayerInfo.jjParticleTimer[1] -= fps;											// see if add particles
 	if (gPlayerInfo.jjParticleTimer[1] <= 0.0f)
 	{
 		gPlayerInfo.jjParticleTimer[1] += .05f;									// reset timer
 
-		particleGroup 	= gPlayerInfo.jjParticleGroup[1];
-		magicNum 		= gPlayerInfo.jjParticleMagic[1];
+		particleGroup = gPlayerInfo.jjParticleGroup[1];
+		magicNum = gPlayerInfo.jjParticleMagic[1];
 
 		if ((particleGroup == -1) || (!VerifyParticleGroupMagicNum(particleGroup, magicNum)))
 		{
 			gPlayerInfo.jjParticleMagic[1] = magicNum = MyRandomLong();			// generate a random magic num
 
-			groupDef.magicNum				= magicNum;
-			groupDef.type					= PARTICLE_TYPE_FALLINGSPARKS;
-			groupDef.flags					= PARTICLE_FLAGS_DONTCHECKGROUND;
-			groupDef.gravity				= 0;
-			groupDef.magnetism				= 0;
-			groupDef.baseScale				= 20.0f * gPlayerInfo.scaleRatio;
-			groupDef.decayRate				= -.2;
-			groupDef.fadeRate				= .7;
-			groupDef.particleTextureNum		= PARTICLE_SObjType_GreySmoke;
-			groupDef.srcBlend				= GL_SRC_ALPHA;
-			groupDef.dstBlend				= GL_ONE_MINUS_SRC_ALPHA;
+			groupDef.magicNum = magicNum;
+			groupDef.type = PARTICLE_TYPE_FALLINGSPARKS;
+			groupDef.flags = PARTICLE_FLAGS_DONTCHECKGROUND;
+			groupDef.gravity = 0;
+			groupDef.magnetism = 0;
+			groupDef.baseScale = 20.0f * gPlayerInfo.scaleRatio;
+			groupDef.decayRate = -.2;
+			groupDef.fadeRate = .7;
+			groupDef.particleTextureNum = PARTICLE_SObjType_GreySmoke;
+			groupDef.srcBlend = GL_SRC_ALPHA;
+			groupDef.dstBlend = GL_ONE_MINUS_SRC_ALPHA;
 			gPlayerInfo.jjParticleGroup[1] = particleGroup = NewParticleGroup(&groupDef);
 		}
 
@@ -3100,13 +3133,13 @@ OGLPoint3D			particleBase;
 				d.y = RandomFloat2() * 40.0f;
 				d.z = RandomFloat2() * 40.0f;
 
-				newParticleDef.groupNum		= particleGroup;
-				newParticleDef.where		= &p;
-				newParticleDef.delta		= &d;
-				newParticleDef.scale		= RandomFloat() + 1.0f;
-				newParticleDef.rotZ			= RandomFloat() * PI2;
-				newParticleDef.rotDZ		= RandomFloat2();
-				newParticleDef.alpha		= .4f + RandomFloat() * .3f;
+				newParticleDef.groupNum = particleGroup;
+				newParticleDef.where = &p;
+				newParticleDef.delta = &d;
+				newParticleDef.scale = RandomFloat() + 1.0f;
+				newParticleDef.rotZ = RandomFloat() * PI2;
+				newParticleDef.rotDZ = RandomFloat2();
+				newParticleDef.alpha = .4f + RandomFloat() * .3f;
 				if (AddParticleToGroup(&newParticleDef))
 				{
 					gPlayerInfo.jjParticleGroup[1] = -1;
@@ -3123,7 +3156,7 @@ OGLPoint3D			particleBase;
 
 /*********************** SET PLAYER WALK ANIM *******************************/
 
-void SetPlayerWalkAnim(ObjNode *theNode)
+void SetPlayerWalkAnim(ObjNode* theNode)
 {
 	if (gPlayerInfo.holdingGun)
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_WALKWITHGUN, 9);
@@ -3134,7 +3167,7 @@ void SetPlayerWalkAnim(ObjNode *theNode)
 
 /********************* IS PLAYER DOING WALK ANIM *********************/
 
-static Boolean IsPlayerDoingWalkAnim(ObjNode *theNode)
+static Boolean IsPlayerDoingWalkAnim(ObjNode* theNode)
 {
 	if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_WALK) ||
 		(theNode->Skeleton->AnimNum == PLAYER_ANIM_WALKWITHGUN))
@@ -3148,7 +3181,7 @@ static Boolean IsPlayerDoingWalkAnim(ObjNode *theNode)
 
 /*********************** SET PLAYER STAND ANIM *******************************/
 
-void SetPlayerStandAnim(ObjNode *theNode, float speed)
+void SetPlayerStandAnim(ObjNode* theNode, float speed)
 {
 	if (gPlayerInfo.holdingGun)
 		MorphToSkeletonAnim(theNode->Skeleton, PLAYER_ANIM_STANDWITHGUN, speed);
@@ -3159,7 +3192,7 @@ void SetPlayerStandAnim(ObjNode *theNode, float speed)
 
 /********************* IS PLAYER DOING STAND ANIM *********************/
 
-static Boolean IsPlayerDoingStandAnim(ObjNode *theNode)
+static Boolean IsPlayerDoingStandAnim(ObjNode* theNode)
 {
 	if ((theNode->Skeleton->AnimNum == PLAYER_ANIM_STAND) ||
 		(theNode->Skeleton->AnimNum == PLAYER_ANIM_STANDWITHGUN))
@@ -3188,17 +3221,17 @@ void StartWeaponChangeAnim(void)
 
 /**************** DO PLAYER MAGNET SKIING ****************************/
 
-static void DoPlayerMagnetSkiing(ObjNode *player)
+static void DoPlayerMagnetSkiing(ObjNode* player)
 {
-short		magnetMonsterID;
-ObjNode		*magMonster;
-float		distToTarget,mx,mz,tx,tz,y;
-OGLVector2D	v;
-float		fps = gFramesPerSecondFrac;
-OGLMatrix3x3	m;
+	short		magnetMonsterID;
+	ObjNode* magMonster;
+	float		distToTarget, mx, mz, tx, tz, y;
+	OGLVector2D	v;
+	float		fps = gFramesPerSecondFrac;
+	OGLMatrix3x3	m;
 
 
-			/* GET INFO ABOUT THE MAGNET MONSTER */
+	/* GET INFO ABOUT THE MAGNET MONSTER */
 
 	magnetMonsterID = gTargetPickup->MagnetMonsterID;		// get ID# of the magnet so we know which monster to go to
 	magMonster = gMagnetMonsterList[magnetMonsterID];		// get objNode of magnet monster
@@ -3208,44 +3241,44 @@ OGLMatrix3x3	m;
 	mx = magMonster->Coord.x;
 	mz = magMonster->Coord.z;
 
-			/* KEEP PLAYER AIMED AT IT */
+	/* KEEP PLAYER AIMED AT IT */
 
 	TurnObjectTowardTarget(player, &gCoord, mx, mz, 11.0, false);
 
 
 
 
-			/*******************/
-			/* CALC AIM VECTOR */
-			/*******************/
+	/*******************/
+	/* CALC AIM VECTOR */
+	/*******************/
 
-		/* CALC VEC FROM MONSTER TO PLAYER */
+/* CALC VEC FROM MONSTER TO PLAYER */
 
 	v.x = gCoord.x - mx;									// calc vector from monster to player
 	v.y = gCoord.z - mz;
 	FastNormalizeVector2D(v.x, v.y, &v, true);
 
 
-			/* ROTATE BASED ON PLAYER INPUT */
+	/* ROTATE BASED ON PLAYER INPUT */
 
 	OGLMatrix3x3_SetRotate(&m, gPlayerInfo.analogControlX * .5f);
 	OGLVector2D_Transform(&v, &m, &v);
 
 
 
-			/* CALC ACCELERATION */
+	/* CALC ACCELERATION */
 
 	tx = mx + v.x * TARGET_SKIING_DIST;						// calc target point where we'd like to be
 	tz = mz + v.y * TARGET_SKIING_DIST;
 
-	distToTarget = CalcDistance(gCoord.x, gCoord.z,  tx, tz);							// calc dist to target point
+	distToTarget = CalcDistance(gCoord.x, gCoord.z, tx, tz);							// calc dist to target point
 	if (distToTarget > 2000.0f)								// limit it
 		distToTarget = 2000.0f;
 
 
-			/***********/
-			/* MOVE IT */
-			/***********/
+	/***********/
+	/* MOVE IT */
+	/***********/
 
 	gDelta.x = distToTarget * -v.x * 1.5f;
 	gDelta.z = distToTarget * -v.y * 1.5f;
@@ -3256,11 +3289,11 @@ OGLMatrix3x3	m;
 	gCoord.z += gDelta.z * fps;
 
 
-			/***********************/
-			/* SEE IF HIT ANYTHING */
-			/***********************/
+	/***********************/
+	/* SEE IF HIT ANYTHING */
+	/***********************/
 
-			/* SEE IF HIT WATER */
+	/* SEE IF HIT WATER */
 
 	if (GetWaterY(gCoord.x, gCoord.z, &y))					// get water y
 	{
@@ -3282,7 +3315,7 @@ OGLMatrix3x3	m;
 		}
 	}
 
-			/* SEE IF HIT GROUND */
+	/* SEE IF HIT GROUND */
 
 	y = GetTerrainY(gCoord.x, gCoord.z);					// get terrain y
 	if ((gCoord.y + player->BBox.min.y) <= y)				// see if hit ground
@@ -3294,7 +3327,7 @@ OGLMatrix3x3	m;
 	}
 
 
-			/* SEE IF HIT SOLID OBJECT HARD */
+	/* SEE IF HIT SOLID OBJECT HARD */
 
 	if (HandleCollisions(player, CTYPE_MISC, -.6) || DoFenceCollision(player))
 	{
@@ -3304,9 +3337,9 @@ OGLMatrix3x3	m;
 		}
 	}
 
-			/***********************/
-			/* SEE IF ABORT SKIING */
-			/***********************/
+	/***********************/
+	/* SEE IF ABORT SKIING */
+	/***********************/
 
 	if (gTargetPickup != nil)															// see if already aborted via collision
 	{
@@ -3325,15 +3358,15 @@ OGLMatrix3x3	m;
 
 /******************** END MAGNET SKIING **************************/
 
-static void EndMagnetSkiing(ObjNode *player, Boolean crash)
+static void EndMagnetSkiing(ObjNode* player, Boolean crash)
 {
-short		magnetMonsterID;
-ObjNode		*magMonster;
+	short		magnetMonsterID;
+	ObjNode* magMonster;
 
 	if (gTargetPickup == nil)					// this can get called twice, so check if pickup==nil
 		return;
 
-			/* GET INFO ABOUT THE MAGNET MONSTER */
+	/* GET INFO ABOUT THE MAGNET MONSTER */
 
 	magnetMonsterID = gTargetPickup->MagnetMonsterID;		// get ID# of the magnet so we know which monster to go to
 	magMonster = gMagnetMonsterList[magnetMonsterID];		// get objNode of magnet monster

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -337,7 +337,7 @@ void MovePlayer_Robot(ObjNode* theNode)
 	/* SEE IF SHOULD FREEZE CAMERA */
 
 	if (theNode->Skeleton->AnimNum == PLAYER_ANIM_JUMPJET)		// dont move camera from during jump-jet
-		gFreezeCameraFromXZ = true;
+		gFreezeCameraFromXZ = false; // Do move it in VR
 	else
 		gFreezeCameraFromXZ = false;
 }

--- a/src/Player/Player_Robot.c
+++ b/src/Player/Player_Robot.c
@@ -1961,14 +1961,14 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 
 	if (true) // (Gives better mouse control?) Seems to prevent player from turning when colliding 
 	{
-		float	rotation, sens;
+		float	sens;
 
 		// analogControlX is mouse only now
 		sens = gPlayerInfo.analogControlX * fps * CONTROL_SENSITIVITY_PR_TURN;
 		
 		sens *= 0.5f; // sensitivity for turning camera (horizontally)
 
-		rotation = theNode->Rot.y -= sens; // Set rotate view (view follows robot rot) with analogControl (mouse)
+		theNode->Rot.y -= sens; // Set rotate view (view follows robot rot) with analogControl (mouse)
 
 
 		float	strafe, movement;
@@ -1977,7 +1977,7 @@ static Boolean DoPlayerMovementAndCollision(ObjNode* theNode, Byte aimMode, Bool
 		if (gPlayerInfo.strafeControlX) {
 			// We are only strafing (no forward nor backward):
 			if (gPlayerInfo.analogControlZ == 0) {
-				strafe = theNode->Rot.y + PI/2;
+				strafe = theNode->Rot.y + PI / 2;
 			}
 			// We are moving forward:
 			else if (gPlayerInfo.analogControlZ < 0) {
@@ -2532,9 +2532,11 @@ static void DoRobotFrictionAndGravity(ObjNode* theNode, float friction)
 	// Dont do friction if player is pressing controls
 	//
 
-	if (!gGamePrefs.playerRelControls)
+	if (true) // Always player relative controls in VR
 	{
-		if (gPlayerInfo.analogControlX || gPlayerInfo.analogControlZ)	// if there is any player control then no friction
+		/* Removed "analogControlX" from here as that is for mouse movement only. If we don't 
+		   do friction when there is mouse movement we get the bug of moving mouse = always move (ref fordcars/OttoMatic-VR#7) */
+		if (gPlayerInfo.analogControlZ || gPlayerInfo.strafeControlX)	// if there is any player control then no friction
 			return;
 	}
 	else										// with player relative controls, do heavier friction in some cases

--- a/src/Player/Player_Weapons.c
+++ b/src/Player/Player_Weapons.c
@@ -884,8 +884,10 @@ float		x,y,z, ex,ey,ez;
 
 
 			/* IF FOUND SOMETHING, THEN ADJUST AIM TO IT */
-
-	if (nearestEnemy)
+	
+	// Disabled for VR / FPV
+	// This might make aiming too hard in VR? Will have to test
+	if (false) // default is if nearestEnemy -> switched off for VR
 	{
 		aim->x += bestAngle.x * 4.0f;									// average the two, but weighted on the bestAngle aim
 		aim->y += bestAngle.y * 4.0f;

--- a/src/System/input.c
+++ b/src/System/input.c
@@ -321,14 +321,12 @@ void UpdateInput(void)
 		float mouseDX = mdx * mouseSensitivityFrac * .1f;
 		float mouseDY = mdy * mouseSensitivityFrac * .1f;
 
-		mouseDX = GAME_CLAMP(mouseDX, -1.0f, 1.0f);					// keep values pinned
-		mouseDY = GAME_CLAMP(mouseDY, -1.0f, 1.0f);
+		// Don't pin the values for better (smoother) mouse fps control
+		//mouseDX = GAME_CLAMP(mouseDX, -1.0f, 1.0f);					// keep values pinned
+		//mouseDY = GAME_CLAMP(mouseDY, -1.0f, 1.0f);
 
 		if (fabsf(mouseDX) > fabsf(gPlayerInfo.analogControlX))		// is the mouse delta better than what we've got from the other devices?
 			gPlayerInfo.analogControlX = mouseDX;
-
-		if (fabsf(mouseDY) > fabsf(gPlayerInfo.analogControlZ))		// is the mouse delta better than what we've got from the other devices?
-			gPlayerInfo.analogControlZ = mouseDY;
 	}
 
 
@@ -339,9 +337,9 @@ void UpdateInput(void)
 
 	if (gSDLController)
 	{
-		OGLVector2D rsVec = GetThumbStickVector(true);
-		gCameraControlDelta.x -= rsVec.x * 1.0f;
-		gCameraControlDelta.y += rsVec.y * 1.0f;
+		//OGLVector2D rsVec = GetThumbStickVector(true);
+		//gCameraControlDelta.x -= rsVec.x * 1.0f;
+		//gCameraControlDelta.y += rsVec.y * 1.0f;
 	}
 
 	if (GetNeedState(kNeed_CameraLeft))
@@ -350,8 +348,12 @@ void UpdateInput(void)
 	if (GetNeedState(kNeed_CameraRight))
 		gCameraControlDelta.x += 1.0f;
 
-	if (!gGamePrefs.mouseControlsOtto)
+	if (!gGamePrefs.mouseControlsOtto) 
 		gCameraControlDelta.x -= mdx * mouseSensitivityFrac * 0.04f;
+	else {
+		// While mouse controls Otto (which it always should in FPS), get the camera y stuff here
+		gCameraControlDelta.y += mdy * mouseSensitivityFrac * 0.008f;
+	}
 }
 
 void CaptureMouse(Boolean doCapture)

--- a/src/System/input.c
+++ b/src/System/input.c
@@ -297,10 +297,12 @@ void UpdateInput(void)
 
 
 	if (GetNeedState(kNeed_TurnLeft))							// is Left Key pressed?
-		gPlayerInfo.analogControlX = -1.0f;
+		gPlayerInfo.strafeControlX = -1.0f;
 	else
 	if (GetNeedState(kNeed_TurnRight))						// is Right Key pressed?
-		gPlayerInfo.analogControlX = 1.0f;
+		gPlayerInfo.strafeControlX = 1.0f;
+	else
+		gPlayerInfo.strafeControlX = 0.0f;			// Make sure not strafing when not pressing strafe
 
 
 	if (GetNeedState(kNeed_Forward))							// is Up Key pressed?


### PR DESCRIPTION
This replaces the default camera system in Otto Matic with a FPV only camera, which will be required for our VR port as we are looking to make the game a first person VR experience.
Featuring:
- Strafe controls instead of turn (A - D or left arrow - right arrow)
- Mouse look up and down, left and right
- Mouse left/right turns Otto, allowing you to walk with W or up arrow, and turn with the mouse like in any other FPS game.
- FPV in rocket (with limitations) and during jump-jet, as opposed to the game's default "freeze camera and point towards player" during those scenes.


## Known issues
- Camera Y axis free but X-Z axis locked in rocket (mentioned in #3)
  - This is because the Y axis (mouse vertical) simply moves the camera y axis, whereas the XZ (mouse horizontal) axes physically turn Otto. In the rocket scenes, Otto can't move so that includes physically turning on himself. Allowing Otto to move makes him able to jump off the rocket before landing which is not an option. Potential solutions
    - Find a way to make Otto turn on himself without allowing him to move forward or back or strafe
    - Ignore this issue and see how it feels in VR (might be horrible to have head axis locked?)
- ~~#8~~ Fixed with this pull request
- Not tested at all with saucer level. In fact, not tested in many levels, this probably has several unknown issues but this is the known issues section. Prototype.

<br>
closes #2 